### PR TITLE
Backend: Graph editor flags one way paths

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
@@ -96,7 +96,10 @@ value class Graph(
                 if (node.extraWeight != 0) out.name("ExtraWeight").value(node.extraWeight)
                 // JSON key intentionally kept as "Neighbours" for backward compatibility
                 out.name("Neighbours").beginObject()
-                for ((neighbor, weight) in node.neighbors) {
+
+                // sort neighbors by id of the node
+                val sorted = node.neighbors.toList().sortedBy { it.first.id }
+                for ((neighbor, weight) in sorted) {
                     out.name(neighbor.id.toString()).value(weight.roundTo(2))
                 }
                 out.endObject()

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
@@ -6,6 +6,9 @@ import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 
+/**
+ * The object we work with in code with features that work wiith navigation or area detetion
+ */
 class GraphNode(
     val id: Int,
     override val position: LorenzVec,

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -161,18 +161,16 @@ enum class GraphNodeTag(
         onlyIsland = IslandType.TORRHUS_CANYON,
     ),
 
-    // TODO fix inconsistent name
     TREE_PROTECTION_ORDER(
-        "tree_protection",
+        "tree_protection_order",
         LorenzColor.RED,
         "Tree Protection Order",
         "Tree Protected by the Protection Order.",
         onlyIslands = IslandTypeTag.FORAGING_CUSTOM_TREES,
     ),
 
-    // TODO fix inconsistent name
     HONEY_HIVE(
-        "hive",
+        "honey_hive",
         LorenzColor.GOLD,
         "Honey Hive",
         "Lootable Honey Hive.",
@@ -184,6 +182,14 @@ enum class GraphNodeTag(
         LorenzColor.GOLD,
         "Safari Bell",
         "Bells to be rung in the Safari.",
+        onlyIsland = IslandType.SAFARI,
+    ),
+
+    HIDEYHO_LOCATION(
+        "hideyho_location",
+        LorenzColor.LIGHT_PURPLE,
+        "Hideyho Location",
+        "A location that Hideyho can be found.",
         onlyIsland = IslandType.SAFARI,
     ),
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -29,8 +29,10 @@ import java.awt.Color
 object GraphEditorBugFinder {
 
     private const val ERROR_LINE_HEIGHT = 10f
+    private const val MAX_RENDERED_NODES = 10
 
     private var errorsInWorld = emptyMap<GraphNode, Set<String>>()
+    private var renderedErrors = emptyList<Pair<GraphNode, Set<String>>>()
 
     private enum class BugCategory(val displayName: String) {
         CONFLICTING_TAGS("conflicting tags"),
@@ -74,6 +76,7 @@ object GraphEditorBugFinder {
         checkOneWayEdges(graph, bugs)
 
         errorsInWorld = bugs.errors
+        updateRenderedErrors()
         reportBugCount(bugs)
         bugs.errors.keys.minByOrNull {
             it.distanceSqToPlayer()
@@ -185,10 +188,24 @@ object GraphEditorBugFinder {
     }
 
     @HandleEvent
+    private fun onSecondPassed() {
+        if (!isEnabled()) return
+        updateRenderedErrors()
+    }
+
+    /** Only the closest nodes are rendered, so a graph with many errors stays readable. */
+    private fun updateRenderedErrors() {
+        renderedErrors = errorsInWorld.entries
+            .sortedBy { it.key.distanceSqToPlayer() }
+            .take(MAX_RENDERED_NODES)
+            .map { it.toPair() }
+    }
+
+    @HandleEvent
     private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
-        for ((node, texts) in errorsInWorld) {
+        for ((node, texts) in renderedErrors) {
             for ((index, text) in texts.withIndex()) {
                 event.drawDynamicText(node.position, text, 1.5, yOff = index * ERROR_LINE_HEIGHT)
             }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -156,7 +156,7 @@ object GraphEditorBugFinder {
                 val neighboringAreaNode = nearestArea[neighbor]?.name ?: continue
                 if (neighboringAreaNode == areaNode) continue
                 if ((null == node.getAreaTag())) {
-                    bugs.add(node, BugCategory.CONFLICTING_AREAS, "Conflicting areas $areaNode and$neighboringAreaNode")
+                    bugs.add(node, BugCategory.CONFLICTING_AREAS, "Conflicting areas $areaNode and $neighboringAreaNode")
                 }
             }
         }
@@ -182,7 +182,7 @@ object GraphEditorBugFinder {
             for (neighbor in node.neighbors.keys) {
                 if (hasPathBack(start = neighbor, target = node)) continue
 
-                bugs.add(node, BugCategory.ONE_WAY_EDGES, "one-way edge starts here (no way back)")
+                bugs.add(node, BugCategory.ONE_WAY_EDGES, "one-way edge starts here")
                 bugs.add(neighbor, BugCategory.ONE_WAY_EDGES, "one-way edge ends here (no way back)")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -20,10 +20,24 @@ import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import java.awt.Color
 
-// Trying to find errors in Area Graph for the current graph editor instance
+/**
+ * Trying to find errors in Area Graph for the current graph editor instance
+ */
 @SkyHanniModule
 object GraphEditorBugFinder {
-    private var errorsInWorld = emptyMap<GraphNode, String>()
+
+    private const val ERROR_LINE_HEIGHT = 10f
+
+    private var errorsInWorld = emptyMap<GraphNode, Set<String>>()
+
+    /** Collects all errors found during a single test run. A node can have more than one error. */
+    private class BugCollector {
+        val errors = mutableMapOf<GraphNode, MutableSet<String>>()
+
+        fun add(node: GraphNode, error: String) {
+            errors.getOrPut(node) { mutableSetOf() }.add(error)
+        }
+    }
 
     fun runTests() {
         CoroutineSettings("graph editor bug finder").launchCoroutine {
@@ -33,79 +47,70 @@ object GraphEditorBugFinder {
 
     private fun asyncTest() {
         val graph = IslandGraphs.currentIslandGraph ?: return
-        val errorsInWorld: MutableMap<GraphNode, String> = mutableMapOf()
+        val bugs = BugCollector()
 
-        checkConflictingTags(graph, errorsInWorld)
-        checkConflictingAreas(graph, errorsInWorld)
-        checkMissingData(graph, errorsInWorld)
-        checkDeprecatedTags(graph, errorsInWorld)
-        checkInvalidNames(graph, errorsInWorld)
-        checkHasSpawn(graph, errorsInWorld)
+        checkConflictingTags(graph, bugs)
+        checkConflictingAreas(graph, bugs)
+        checkMissingData(graph, bugs)
+        checkDeprecatedTags(graph, bugs)
+        checkInvalidNames(graph, bugs)
+        checkHasSpawn(graph)
+        checkOneWayEdges(graph, bugs)
 
-        this.errorsInWorld = errorsInWorld
-        errorsInWorld.keys.minByOrNull {
+        errorsInWorld = bugs.errors
+        bugs.errors.keys.minByOrNull {
             it.distanceSqToPlayer()
         }?.pathFind("Graph Editor Bug", Color.RED, condition = { isEnabled() })
     }
 
-    private fun checkDeprecatedTags(
-        graph: Graph,
-        errorsInWorld: MutableMap<GraphNode, String>,
-    ) {
+    private fun checkDeprecatedTags(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             @Suppress("DEPRECATION")
             if (node.hasTag(GraphNodeTag.TELEPORT)) {
-                errorsInWorld[node] = "deprecated teleport node"
+                bugs.add(node, "deprecated teleport node")
             }
         }
     }
 
-    private fun checkInvalidNames(
-        graph: Graph,
-        errorsInWorld: MutableMap<GraphNode, String>,
-    ) {
+    private fun checkInvalidNames(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             val name = node.name ?: continue
             if (node.hasTag(GraphNodeTag.WARP)) {
                 if (!name.startsWith("/")) {
-                    errorsInWorld[node] = "invalid warp name"
+                    bugs.add(node, "invalid warp name")
                 }
             }
             if (node.hasTag(GraphNodeTag.JUMP_PAD)) {
                 if (IslandType.entries.none { it.name == name }) {
-                    errorsInWorld[node] = "jump pad name is no known island name"
+                    bugs.add(node, "jump pad name is no known island name")
                 }
                 if (name == SkyBlockUtils.currentIsland.name) {
-                    errorsInWorld[node] = "jump pad name is current island name"
+                    bugs.add(node, "jump pad name is current island name")
                 }
             }
         }
     }
 
-    @Suppress("UnusedParameter")
-    private fun checkHasSpawn(
-        graph: Graph,
-        errorsInWorld: MutableMap<GraphNode, String>,
-    ) {
+    private fun checkHasSpawn(graph: Graph) {
         if (graph.none { it.hasTag(GraphNodeTag.POI) && it.name == "Spawn" }) {
             ChatUtils.chat("§cGraph editor without spawn point!")
         }
     }
 
-    private fun checkMissingData(graph: Graph, errorsInWorld: MutableMap<GraphNode, String>) {
+    private fun checkMissingData(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             val nameNull = node.name.isNullOrBlank()
             val tagsEmpty = node.tags.isEmpty()
             if (nameNull > tagsEmpty) {
-                errorsInWorld[node] = "Missing name despite having tags"
+                bugs.add(node, "Missing name despite having tags")
             }
             if (tagsEmpty > nameNull) {
-                errorsInWorld[node] = "Missing tags despite having name"
+                bugs.add(node, "Missing tags despite having name")
             }
         }
     }
 
-    private fun checkConflictingAreas(graph: Graph, errorsInWorld: MutableMap<GraphNode, String>) {
+    private fun checkConflictingAreas(graph: Graph, bugs: BugCollector) {
         val nearestArea = mutableMapOf<GraphNode, GraphNode>()
         for (node in graph) {
             val pathToNearestArea = GraphUtils.findFastestPath(node) { it.getAreaTag() != null }?.first
@@ -121,33 +126,45 @@ object GraphEditorBugFinder {
                 val neighboringAreaNode = nearestArea[neighbor]?.name ?: continue
                 if (neighboringAreaNode == areaNode) continue
                 if ((null == node.getAreaTag())) {
-                    errorsInWorld[node] = "Conflicting areas $areaNode and $neighboringAreaNode"
+                    bugs.add(node, "Conflicting areas $areaNode and $neighboringAreaNode")
                 }
             }
         }
     }
 
-    private fun checkConflictingTags(graph: Graph, errorsInWorld: MutableMap<GraphNode, String>) {
+    private fun checkConflictingTags(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             if (!node.tags.any { it in NavigationHelper.allowedTags }) continue
             val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
             if (remainingTags.size != 1) {
-                errorsInWorld[node] = "Conflicting tags: $remainingTags"
+                bugs.add(node, "Conflicting tags: $remainingTags")
             }
             if (node.hasTag(GraphNodeTag.MINES_EMISSARY)) {
                 if (!node.hasTag(GraphNodeTag.NPC)) {
-                    errorsInWorld[node] = "emissary without npc tag"
+                    bugs.add(node, "emissary without npc tag")
                 }
+            }
+        }
+    }
+
+    private fun checkOneWayEdges(graph: Graph, bugs: BugCollector) {
+        for (node in graph) {
+            for (neighbor in node.neighbors.keys) {
+                if (node in neighbor.neighbors) continue
+                bugs.add(node, "one-way edge starts here")
+                bugs.add(neighbor, "one-way edge ends here (no way back)")
             }
         }
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
-        for ((node, text) in errorsInWorld) {
-            event.drawDynamicText(node.position, text, 1.5)
+        for ((node, texts) in errorsInWorld) {
+            for ((index, text) in texts.withIndex()) {
+                event.drawDynamicText(node.position, text, 1.5, yOff = index * ERROR_LINE_HEIGHT)
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -180,11 +180,27 @@ object GraphEditorBugFinder {
     private fun checkOneWayEdges(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             for (neighbor in node.neighbors.keys) {
-                if (node in neighbor.neighbors) continue
-                bugs.add(node, BugCategory.ONE_WAY_EDGES, "one-way edge starts here")
+                if (hasPathBack(start = neighbor, target = node)) continue
+
+                bugs.add(node, BugCategory.ONE_WAY_EDGES, "one-way edge starts here (no way back)")
                 bugs.add(neighbor, BugCategory.ONE_WAY_EDGES, "one-way edge ends here (no way back)")
             }
         }
+    }
+
+    private fun hasPathBack(start: GraphNode, target: GraphNode): Boolean {
+        val queue = ArrayDeque<GraphNode>().apply { add(start) }
+        val visited = mutableSetOf(start)
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (current == target) return true
+
+            for (next in current.neighbors.keys) {
+                if (visited.add(next)) queue.add(next)
+            }
+        }
+        return false
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -15,7 +15,9 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.GraphUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import java.awt.Color
@@ -30,12 +32,26 @@ object GraphEditorBugFinder {
 
     private var errorsInWorld = emptyMap<GraphNode, Set<String>>()
 
+    private enum class BugCategory(val displayName: String) {
+        CONFLICTING_TAGS("conflicting tags"),
+        CONFLICTING_AREAS("conflicting areas"),
+        MISSING_DATA("missing data"),
+        DEPRECATED_TAGS("deprecated tags"),
+        INVALID_NAMES("invalid names"),
+        ONE_WAY_EDGES("one-way edges"),
+    }
+
     /** Collects all errors found during a single test run. A node can have more than one error. */
     private class BugCollector {
         val errors = mutableMapOf<GraphNode, MutableSet<String>>()
+        val categoryCounts = mutableMapOf<BugCategory, Int>()
 
-        fun add(node: GraphNode, error: String) {
-            errors.getOrPut(node) { mutableSetOf() }.add(error)
+        val totalErrors get() = categoryCounts.values.sum()
+
+        /** Duplicate messages on the same node are dropped and therefore not counted. */
+        fun add(node: GraphNode, category: BugCategory, error: String) {
+            if (!errors.getOrPut(node) { mutableSetOf() }.add(error)) return
+            categoryCounts.addOrPut(category, 1)
         }
     }
 
@@ -58,16 +74,27 @@ object GraphEditorBugFinder {
         checkOneWayEdges(graph, bugs)
 
         errorsInWorld = bugs.errors
+        reportBugCount(bugs)
         bugs.errors.keys.minByOrNull {
             it.distanceSqToPlayer()
         }?.pathFind("Graph Editor Bug", Color.RED, condition = { isEnabled() })
+    }
+
+    private fun reportBugCount(bugs: BugCollector) {
+        val totalErrors = bugs.totalErrors
+        if (totalErrors == 0) return
+        val breakdown = bugs.categoryCounts.entries.sortedByDescending { it.value }
+            .joinToString("\n") { (category, count) -> " §7${category.displayName}: §e${count.addSeparators()}" }
+        ChatUtils.chat(
+            "§cGraph errors: ${totalErrors.addSeparators()} on ${bugs.errors.size.addSeparators()} nodes\n$breakdown",
+        )
     }
 
     private fun checkDeprecatedTags(graph: Graph, bugs: BugCollector) {
         for (node in graph) {
             @Suppress("DEPRECATION")
             if (node.hasTag(GraphNodeTag.TELEPORT)) {
-                bugs.add(node, "deprecated teleport node")
+                bugs.add(node, BugCategory.DEPRECATED_TAGS, "deprecated teleport node")
             }
         }
     }
@@ -77,15 +104,15 @@ object GraphEditorBugFinder {
             val name = node.name ?: continue
             if (node.hasTag(GraphNodeTag.WARP)) {
                 if (!name.startsWith("/")) {
-                    bugs.add(node, "invalid warp name")
+                    bugs.add(node, BugCategory.INVALID_NAMES, "invalid warp name")
                 }
             }
             if (node.hasTag(GraphNodeTag.JUMP_PAD)) {
                 if (IslandType.entries.none { it.name == name }) {
-                    bugs.add(node, "jump pad name is no known island name")
+                    bugs.add(node, BugCategory.INVALID_NAMES, "jump pad name is no known island name")
                 }
                 if (name == SkyBlockUtils.currentIsland.name) {
-                    bugs.add(node, "jump pad name is current island name")
+                    bugs.add(node, BugCategory.INVALID_NAMES, "jump pad name is current island name")
                 }
             }
         }
@@ -102,10 +129,10 @@ object GraphEditorBugFinder {
             val nameNull = node.name.isNullOrBlank()
             val tagsEmpty = node.tags.isEmpty()
             if (nameNull > tagsEmpty) {
-                bugs.add(node, "Missing name despite having tags")
+                bugs.add(node, BugCategory.MISSING_DATA, "Missing name despite having tags")
             }
             if (tagsEmpty > nameNull) {
-                bugs.add(node, "Missing tags despite having name")
+                bugs.add(node, BugCategory.MISSING_DATA, "Missing tags despite having name")
             }
         }
     }
@@ -126,7 +153,7 @@ object GraphEditorBugFinder {
                 val neighboringAreaNode = nearestArea[neighbor]?.name ?: continue
                 if (neighboringAreaNode == areaNode) continue
                 if ((null == node.getAreaTag())) {
-                    bugs.add(node, "Conflicting areas $areaNode and $neighboringAreaNode")
+                    bugs.add(node, BugCategory.CONFLICTING_AREAS, "Conflicting areas $areaNode and$neighboringAreaNode")
                 }
             }
         }
@@ -137,11 +164,11 @@ object GraphEditorBugFinder {
             if (!node.tags.any { it in NavigationHelper.allowedTags }) continue
             val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
             if (remainingTags.size != 1) {
-                bugs.add(node, "Conflicting tags: $remainingTags")
+                bugs.add(node, BugCategory.CONFLICTING_TAGS, "Conflicting tags: $remainingTags")
             }
             if (node.hasTag(GraphNodeTag.MINES_EMISSARY)) {
                 if (!node.hasTag(GraphNodeTag.NPC)) {
-                    bugs.add(node, "emissary without npc tag")
+                    bugs.add(node, BugCategory.CONFLICTING_TAGS, "emissary without npc tag")
                 }
             }
         }
@@ -151,8 +178,8 @@ object GraphEditorBugFinder {
         for (node in graph) {
             for (neighbor in node.neighbors.keys) {
                 if (node in neighbor.neighbors) continue
-                bugs.add(node, "one-way edge starts here")
-                bugs.add(neighbor, "one-way edge ends here (no way back)")
+                bugs.add(node, BugCategory.ONE_WAY_EDGES, "one-way edge starts here")
+                bugs.add(neighbor, BugCategory.ONE_WAY_EDGES, "one-way edge ends here (no way back)")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphingNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphingNode.kt
@@ -5,7 +5,9 @@ import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 
-// The node object the graph editor is working with
+/**
+ * The node object the graph editor is working with
+ */
 class GraphingNode(
     val id: Int,
     override var position: LorenzVec,


### PR DESCRIPTION
## Changelog Technical Details
+ Updated the Graph Editor, especially around errors. - hannibal2
    * Added an error message when a path is one-way and doesn't allow you to go back.
    * Neighbors are now sorted by id to avoid funny-looking diffs.
    * Now only showing the closest 10 errors to improve readability.
    * Now showing error count and category number in chat if there are any.