### PR TITLE
Fix: Sweep Lottery Perk showing +5% instead of +10

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -19,8 +19,8 @@ object HotfApi {
     ) : RotatingPerk {
         SWEEP(
             displayDescription = "§a+10§r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
-            chatFallback = "Gain \\+10%${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
-            itemFallback = "Gain \\+10%${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            chatFallback = "Gain \\+10${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            itemFallback = "Gain \\+10${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
             displayDescription = "§a+50§r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",

--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -18,24 +18,24 @@ object HotfApi {
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         SWEEP(
-            displayDescription = "§a+5%§r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
-            chatFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
-            itemFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            displayDescription = "§a+10§r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
+            chatFallback = "Gain \\+10%${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            itemFallback = "Gain \\+10%${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
             displayDescription = "§a+50§r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
-            chatFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
-            itemFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            chatFallback = "Gain \\+50${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            itemFallback = "Gain \\+50${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
             displayDescription = "§a+50§r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
-            chatFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
-            itemFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            chatFallback = "Gain \\+50${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            itemFallback = "Gain \\+50${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         HELIX_FORTUNE(
             displayDescription = "§a+50§r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
-            chatFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
-            itemFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
+            chatFallback = "Gain \\+50${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
+            itemFallback = "Gain \\+50${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
         ),
         ;
 


### PR DESCRIPTION
## What
Add the tag "Waiting on Hypixel" for this one.

I removed the optional " ?" stuff.
And also changed it from 5% to 10 like luna said.

Has not been tested.


ignore_from_changelog
(old one, new one is at: https://github.com/hannibal002/SkyHanni/pull/6270)

## Changelog Fixes
+ Fixed Lottery Perk Display showing +5% Sweep instead of +10 Sweep. - Avrg