### PR TITLE
Fix: Cold not resetting outside cold areas

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -217,7 +217,8 @@ object MiningApi {
 
     /**
      * Whether cold can currently apply to the player.
-     * On the Critter Safari cold only exists inside the Icy Biome, on the other cold islands it applies everywhere.
+     * On the Critter Safari cold is limited to the Icy Biome, which is why the area is checked here.
+     * The other cold islands are not narrowed down further, there we rely on Hypixel removing the scoreboard line.
      */
     fun inColdArea(): Boolean {
         if (!IslandTypeTag.IS_COLD.isInIsland()) return false

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.OreMinedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
+import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.dungeonRoomPattern
 import at.hannibal2.skyhanni.features.mining.OreBlock
@@ -56,6 +57,8 @@ object MiningApi {
      * REGEX-TEST: Mines of Divan
      */
     private val minesOfDivanPattern by group.pattern("area.minesofdivan", "Mines of Divan")
+
+    private val icyBiomePattern by group.pattern("area.icybiome", "Icy Biome")
 
     /**
      * REGEX-TEST: §6The warmth of the campfire reduced your §r§b Cold §r§6to §r§a0§r§6!
@@ -212,20 +215,37 @@ object MiningApi {
 
     fun inGlacialTunnels() = IslandType.DWARVEN_MINES.isInIsland() && glaciteAreaPattern.matches(SkyBlockUtils.graphArea)
 
+    /**
+     * Whether cold can currently apply to the player.
+     * On the Critter Safari cold only exists inside the Icy Biome, on the other cold islands it applies everywhere.
+     */
+    fun inColdArea(): Boolean {
+        if (!IslandTypeTag.IS_COLD.isInIsland()) return false
+        if (IslandType.SAFARI.isInIsland()) return icyBiomePattern.matches(SkyBlockUtils.graphArea)
+        return true
+    }
+
     @HandleEvent
-    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+    private fun onScoreboardChange(event: ScoreboardUpdateEvent) {
         if (IslandTypeTag.IS_COLD.isInIsland()) {
             dungeonRoomPattern.firstMatcher(event.new) {
                 groupOrNull("roomId")?.let { mineshaftRoomId = it }
             }
 
-            coldPattern.firstMatcher(event.added) {
-                val newCold = group("cold").toInt().absoluteValue
+            var found = false
+            if (inColdArea()) {
+                coldPattern.firstMatcher(event.new) {
+                    found = true
+                    val newCold = group("cold").toInt().absoluteValue
 
-                if (newCold != cold) {
-                    updateCold(newCold)
+                    if (newCold != cold) {
+                        updateCold(newCold)
+                    }
                 }
             }
+            // Cold is reset when the line is gone from the scoreboard, and also when the player left the cold area,
+            // since Hypixel does not reliably remove the line in that case.
+            if (!found) resetCold()
         }
 
         if (IslandType.CRYSTAL_HOLLOWS.isInIsland()) {
@@ -408,9 +428,15 @@ object MiningApi {
     }
 
     @HandleEvent(ScoreboardAreaChangeEvent::class)
-    fun onAreaChange() {
+    private fun onGraphAreaChange() {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         updateLocation()
+    }
+
+    // Resets cold the moment the player leaves a cold area, without waiting for the scoreboard to catch up.
+    @HandleEvent(GraphAreaChangeEvent::class)
+    private fun onAreaChange() {
+        if (!inColdArea()) resetCold()
     }
 
     @HandleEvent
@@ -517,6 +543,12 @@ object MiningApi {
             add("")
             add("recentlyClickedBlocks: ${recentClickedBlocks.keys.joinToString { "(${it.toCleanString()})" }}")
         }
+    }
+
+    private fun resetCold() {
+        if (cold == 0) return
+        updateCold(0)
+        lastColdReset = SimpleTimeMark.now()
     }
 
     private fun updateCold(newCold: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -428,7 +428,7 @@ object MiningApi {
     }
 
     @HandleEvent(ScoreboardAreaChangeEvent::class)
-    private fun onGraphAreaChange() {
+    private fun onScoreboardAreaChange() {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         updateLocation()
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -245,7 +245,7 @@ object MiningApi {
                 }
             }
             // Cold is reset when the line is gone from the scoreboard, and also when the player left the cold area,
-            // since Hypixel does not reliably remove the line in that case.
+            // since Hypixel only removes the line after a delay.
             if (!found) resetCold()
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.events.mining.OreMinedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
 import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
-import at.hannibal2.skyhanni.features.dungeon.DungeonApi.dungeonRoomPattern
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.mining.OreBlock
 import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -228,7 +228,7 @@ object MiningApi {
     @HandleEvent
     private fun onScoreboardChange(event: ScoreboardUpdateEvent) {
         if (IslandTypeTag.IS_COLD.isInIsland()) {
-            dungeonRoomPattern.firstMatcher(event.new) {
+            DungeonApi.dungeonRoomPattern.firstMatcher(event.new) {
                 groupOrNull("roomId")?.let { mineshaftRoomId = it }
             }
 


### PR DESCRIPTION

## What
Reproduced on the alpha Critter Safari without this PR: when leaving the Icy Biome, Hypixel removes the Cold line from the scoreboard, but the Cold Overlay stays on screen indefinitely. Once Hypixel stopped showing it, the last known value stayed forever, and every feature built on `ColdUpdateEvent` kept believing the player was freezing.

Cold now follows the same shape the Heat handling a few lines below already used: read the value from the full current scoreboard, and reset it to 0 when it is no longer there.

On the Critter Safari, Cold only applies inside the Icy Biome, and Hypixel does not reliably remove the line when leaving it. `MiningApi.inColdArea()` therefore also checks the graph area, and a `GraphAreaChangeEvent` handler resets the value the moment the player leaves the Icy Biome instead of waiting for the scoreboard to catch up.

Both the Cold Overlay and the Custom Scoreboard Cold line are fixed by this without a single change of their own. `ColdOverlay` fades out once its Cold value reaches 0, and `ScoreboardElementCold` returns no line at 0. That was the whole point of fixing it in `MiningApi` instead of adding an area check to every feature that reads Cold.

Split out of #6261 after review feedback from CalMWolfs, since this affects every cold island and not just the Safari.

## Changelog Fixes
+ Fixed the Cold Overlay and the Custom Scoreboard Cold line staying visible after leaving a cold area. - hannibal2
    * Hypixel removes Cold from the scoreboard when leaving the Glacite Tunnels in the Dwarven Mines or the Icy Biome on the Critter Safari, but SkyHanni kept the last known value.
