### PR TITLE
Backend: Area Change Events cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
-import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.IslandAreaBackend
 import at.hannibal2.skyhanni.features.misc.pathfind.IslandAreaFeatures
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationFeedback
@@ -169,7 +168,7 @@ object IslandGraphs {
     )
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<IslandGraphSettingsJson>("misc/IslandGraphSettings")
         ignoredIslandTypes = data.ignoredIslandTypes
 
@@ -179,7 +178,7 @@ object IslandGraphs {
     }
 
     @HandleEvent
-    fun onIslandJoin(event: IslandJoinEvent) {
+    private fun onIslandJoin(event: IslandJoinEvent) {
         enableAllNodes()
         if (currentIslandGraph != null) return
         if (event.island == IslandType.NONE) return
@@ -187,7 +186,7 @@ object IslandGraphs {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         currentIslandGraph = null
         if (currentTarget != null) NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped because of world switch!")
         resetNavigation()
@@ -195,8 +194,8 @@ object IslandGraphs {
 
     private fun isGlaciteTunnelsArea(area: String?): Boolean = glaciteTunnelsPattern.matches(area)
 
-    @HandleEvent(ScoreboardAreaChangeEvent::class)
-    fun onAreaChange() {
+    @HandleEvent
+    private fun onScoreboardAreaChange() {
         if (!IslandType.DWARVEN_MINES.isInIsland()) {
             inGlaciteTunnels = null
             return
@@ -237,7 +236,7 @@ object IslandGraphs {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Island Graphs")
         val islandType = SkyBlockUtils.currentIsland.name
         val isPersonal = IslandTypeTag.PERSONAL_ISLAND.isInIsland()
@@ -323,7 +322,7 @@ object IslandGraphs {
      * calling before [at.hannibal2.skyhanni.test.graph.GraphEditor], so that we always have the latest playerPosition.
      */
     @HandleEvent(priority = -1)
-    fun onTick(event: SkyHanniTickEvent) {
+    private fun onTick(event: SkyHanniTickEvent) {
         GraphUtils.updatePlayerPosition()
         if (currentIslandGraph == null) return
         if (event.isMod(2)) {
@@ -413,9 +412,8 @@ object IslandGraphs {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
-        val graph = currentIslandGraph
-        if (graph == null) return
+    private fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
+        val graph = currentIslandGraph ?: return
         hasMoved = true
 
         if (event.distance > FAST_MOVEMENT_THRESHOLD) {
@@ -573,7 +571,7 @@ object IslandGraphs {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (currentIslandGraph == null) return
         pathRenderer?.render(event)
     }
@@ -586,7 +584,7 @@ object IslandGraphs {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shreportlocation") {
             description = "Allows the user to report an error with pathfinding at the current location."
             category = CommandCategory.USERS_BUG_FIX

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.OreMinedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
-import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.dungeonRoomPattern
 import at.hannibal2.skyhanni.features.mining.OreBlock
 import at.hannibal2.skyhanni.features.mining.isTitanium
@@ -213,7 +212,7 @@ object MiningApi {
     fun inGlacialTunnels() = IslandType.DWARVEN_MINES.isInIsland() && glaciteAreaPattern.matches(SkyBlockUtils.graphArea)
 
     @HandleEvent
-    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+    private fun onScoreboardChange(event: ScoreboardUpdateEvent) {
         if (IslandTypeTag.IS_COLD.isInIsland()) {
             dungeonRoomPattern.firstMatcher(event.new) {
                 groupOrNull("roomId")?.let { mineshaftRoomId = it }
@@ -250,7 +249,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onBlockClick(event: BlockClickEvent) {
+    private fun onBlockClick(event: BlockClickEvent) {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         if (event.clickType != InteractClickType.LEFT_CLICK) return
         if (OreBlock.getByStateOrNull(event.blockState) == null) return
@@ -261,7 +260,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         if (IslandTypeTag.IS_COLD.isInIsland()) {
             if (coldResetPattern.matches(event.message)) {
@@ -291,7 +290,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onPlayerDeath(event: PlayerDeathEvent.Allow) {
+    private fun onPlayerDeath(event: PlayerDeathEvent.Allow) {
         if (event.isSelf) {
             updateCold(0)
             updateHeat(0)
@@ -301,7 +300,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onPlaySound(event: PlaySoundEvent) {
+    private fun onPlaySound(event: PlaySoundEvent) {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         if (event.soundName == "entity.generic.explode" && lastPickobulusUse.passedSince() < 5.seconds) {
             lastPickobulusExplosion = SimpleTimeMark.now()
@@ -345,7 +344,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onBlockChange(event: ServerBlockChangeEvent) {
+    private fun onBlockChange(event: ServerBlockChangeEvent) {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         val oldState = event.oldState
         val newState = event.newState
@@ -389,7 +388,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         if (currentAreaOreBlocks.isEmpty()) return
 
@@ -407,14 +406,14 @@ object MiningApi {
         }
     }
 
-    @HandleEvent(ScoreboardAreaChangeEvent::class)
-    fun onAreaChange() {
+    @HandleEvent
+    private fun onScoreboardAreaChange() {
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) return
         updateLocation()
     }
 
     @HandleEvent
-    fun onIslandChange() {
+    private fun onIslandChange() {
         updateLocation()
 
         mineshaftRoomId = null
@@ -449,7 +448,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         if (cold != 0) updateCold(0)
         lastColdReset = SimpleTimeMark.now()
         recentClickedBlocks.clear()
@@ -483,7 +482,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Mining API")
         if (!IslandTypeTag.CUSTOM_MINING.isInIsland()) {
             event.addIrrelevant("not in a mining island")
@@ -547,7 +546,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val repo = event.getConstant<MiningJson>("Mining")
 
         blockStrengths.clear()

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
-import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerProgressChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerQuestCompleteEvent
@@ -135,7 +134,7 @@ object SlayerApi {
         }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Slayer")
 
         if (!hasActiveQuest()) {
@@ -163,7 +162,7 @@ object SlayerApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.cleanMessage
 
         if (questStartPattern.matches(message)) {
@@ -176,7 +175,7 @@ object SlayerApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick(event: SkyHanniTickEvent) {
+    private fun onTick(event: SkyHanniTickEvent) {
         // wait with sending SlayerChangeEvent until profile is detected
         if (ProfileStorageData.profileSpecific == null) return
 
@@ -248,12 +247,12 @@ object SlayerApi {
     }
 
     @HandleEvent(ScoreboardUpdateEvent::class, onlyOnSkyblock = true)
-    fun onScoreboardChange() {
+    private fun onScoreboardChange() {
         updateSlayerState()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.SLAYER)) return
         updateSlayerState()
     }
@@ -279,14 +278,14 @@ object SlayerApi {
         else -> ActiveQuestState.NO_ACTIVE_QUEST
     }
 
-    @HandleEvent(GraphAreaChangeEvent::class, priority = -1)
-    fun onAreaChange() {
+    @HandleEvent(priority = -1)
+    private fun onAreaChange() {
         currentAreaType = checkTypeForCurrentArea()
         updateArea()
     }
 
     @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         with(trackerConfig) {
             ConditionalUtils.onToggle(revenantInGraveyard, voidgloomInNest, voidgloomInNoArea) {
                 currentAreaType = checkTypeForCurrentArea()

--- a/src/main/java/at/hannibal2/skyhanni/data/WinterApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/WinterApi.kt
@@ -33,7 +33,7 @@ object WinterApi {
     fun isDecember() = TimeUtils.getCurrentLocalDate().month == Month.DECEMBER
 
     @HandleEvent
-    fun onAreaChange(event: GraphAreaChangeEvent) {
+    private fun onAreaChange(event: GraphAreaChangeEvent) {
         inArea = event.area == "Glacial Cave"
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
@@ -1,7 +1,44 @@
 package at.hannibal2.skyhanni.events.skyblock
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-// Detect area changes by looking at the scoreboard.
+/**
+ * Fired when the area name shown on the SkyBlock scoreboard changes.
+ *
+ * This event is a fallback. Almost always prefer [GraphAreaChangeEvent] instead, which is based on the island graph
+ * data. That data is maintained in the SkyHanni repo, so it covers area borders Hypixel does not map out as clearly on the scoreboard,
+ * and it can be corrected without a mod update. Only use this event when graph data is not usable in the given
+ * scenario, for example on islands without graph data, or when the scoreboard name itself is the value that is needed.
+ *
+ * Keep the usage of this event inside backend classes in the data or api packages. Feature classes should not listen
+ * to it directly.
+ *
+ * @param area the area name currently shown on the scoreboard.
+ * @param previousArea the area name shown before this change, or null when no area was known yet.
+ */
+@PrimaryFunction("onScoreboardAreaChange")
 class ScoreboardAreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()
+
+/**
+ * Fired when the player enters a different area, detected from the closest area node in the island graph.
+ *
+ * This is the preferred way to react to area changes and is fair game for feature classes. Use it over
+ * [ScoreboardAreaChangeEvent] unless the graph data cannot answer the question at hand.
+ *
+ * The event is only posted when the area name actually changed. Being outside of every known area is reported as
+ * AreaNode.NO_AREA and is a normal state, not an error. On a world change the area is reset to AreaNode.NO_AREA,
+ * which posts the event unless the player was already outside of every area.
+ *
+ * If only the current area is needed, without reacting to the change itself, use SkyBlockUtils.graphArea instead of
+ * listening to this event.
+ *
+ * @param area the name of the area the player is now in, or AreaNode.NO_AREA when inside no known area.
+ * @param previousArea the area the player was in before this change, empty before the first area of the session has
+ *   been detected.
+ * @param onlyInternal true when this change should not be surfaced to the user, either because the area is hidden by
+ *   the area list config or because the area was reset on a world change. Logic that only cares about where the player
+ *   is should ignore this flag, only user facing displays of the current area should respect it.
+ */
+@PrimaryFunction("onAreaChange")
 class GraphAreaChangeEvent(val area: String, val previousArea: String?, val onlyInternal: Boolean) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -176,7 +176,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onSkillExp(event: SkillExpGainEvent) {
+    private fun onSkillExp(event: SkillExpGainEvent) {
         if (!inArea) return
         if (event.gained > 10_000) return
         tracker.modify {
@@ -185,7 +185,7 @@ object GhostTracker {
     }
 
     @HandleEvent(SecondPassedEvent::class)
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         if (!isEnabled()) return
         if (!TabWidget.BESTIARY.isActive && lastNoWidgetWarningTime.passedSince() > 1.minutes) {
             lastNoWidgetWarningTime = SimpleTimeMark.now()
@@ -208,7 +208,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onSackChange(event: SackChangeEvent) {
+    private fun onSackChange(event: SackChangeEvent) {
         if (!inArea || !ProfileStorageData.loaded) return
 
         val allowedChanges = event.sackChanges.filter {
@@ -223,20 +223,20 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onShard(event: ShardGainEvent) {
+    private fun onShard(event: ShardGainEvent) {
         if (event.shardInternalName != ghostShard) return
         tracker.addItem(ghostShard, event.amount, false)
     }
 
     @HandleEvent
-    fun onItemAdd(event: ItemAddEvent) {
+    private fun onItemAdd(event: ItemAddEvent) {
         if (!inArea || event.source != ItemAddManager.Source.COMMAND) return
 
         tracker.addItem(event.internalName, event.amount, command = true)
     }
 
     @HandleEvent
-    fun onPurseChange(event: PurseChangeEvent) {
+    private fun onPurseChange(event: PurseChangeEvent) {
         if (!inArea) return
         if (event.reason != PurseChangeCause.GAIN_MOB_KILL) return
         if (event.coins !in 200.0..15_000.0) return
@@ -244,7 +244,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!inArea) return
         itemDropPattern.matchMatcher(event.cleanMessage) {
             val internalName = NeuInternalName.fromItemNameOrNull(group("item")) ?: return
@@ -304,7 +304,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.BESTIARY)) return
         if (isMaxBestiary || !inArea) return
         parseBestiaryWidget(event.lines)
@@ -315,20 +315,20 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val ghostDropsConstant = event.getConstant<GhostDropsJson>("GhostDrops")
         allowedDrops = ghostDropsConstant.ghostDrops
         allowedSackDrops = ghostDropsConstant.sacksDrops
     }
 
     @HandleEvent
-    fun onAreaChange(event: GraphAreaChangeEvent) {
+    private fun onAreaChange(event: GraphAreaChangeEvent) {
         inArea = event.area == "The Mist" && IslandType.DWARVEN_MINES.isInIsland()
         if (inArea) parseBestiaryWidget(TabWidget.BESTIARY.lines)
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    private fun onIslandChange(event: IslandChangeEvent) {
         if (event.newIsland == IslandType.DWARVEN_MINES) {
             tracker.firstUpdate()
         }
@@ -373,7 +373,7 @@ object GhostTracker {
     }
 
     @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         val storage = storage ?: return
         if (storage.migratedTotalKills) return
         tracker.modify {
@@ -383,7 +383,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresetghosttracker") {
             description = "Resets the Ghost Profit Tracker"
             category = CommandCategory.USERS_RESET
@@ -392,7 +392,7 @@ object GhostTracker {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
 
         fun migrateItem(oldData: JsonElement): JsonElement {
             val oldAmount = oldData.asInt

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -133,12 +133,12 @@ object TrevorFeatures {
     var lastTitle: TitleContext? = null
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onTick() {
+    private fun onTick() {
         updateTrapper()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         TrevorTracker.update()
         TrevorTracker.calculatePeltsPerHour()
         if (config.solver && questActive) {
@@ -147,7 +147,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         val formattedMessage = event.cleanMessage
 
         mobDiedPattern.matchMatcher(formattedMessage) {
@@ -212,7 +212,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent
-    fun onTabListUpdate(event: TabListUpdateEvent) {
+    private fun onTabListUpdate(event: TabListUpdateEvent) {
         var found = false
         var active = false
         val previousLocation = TrevorSolver.mobLocation
@@ -248,7 +248,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, priority = HandleEvent.LOWEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (!config.cooldownGui) return
 
         val cooldownMessage = if (nextReadyTime.isInPast()) "Trapper Ready"
@@ -280,16 +280,23 @@ object TrevorFeatures {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onEntityEnterWorld(event: EntityEnterWorldEvent<RemotePlayer>) {
+    private fun onEntityEnterWorld(event: EntityEnterWorldEvent<RemotePlayer>) {
         if (trevorTexture != null && event.entity.getSkinTexture() == trevorTexture) trevorEntity = event.entity
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<RemotePlayer>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<RemotePlayer>) {
         if (event.entity == trevorEntity) trevorEntity = null
     }
 
-    private fun renderCooldown(event: SkyHanniRenderWorldEvent) {
+    @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        if (config.cooldown) event.renderCooldown()
+        val mobFound = event.findMob()
+        if (config.talbotCircles && !mobFound) TalbotCircles.drawCircles(event)
+    }
+
+    private fun SkyHanniRenderWorldEvent.renderCooldown() {
         val entity = trevorEntity ?: return
 
         RenderLivingEntityHelper.setEntityColor(entity, currentStatus.color) {
@@ -297,12 +304,12 @@ object TrevorFeatures {
         }
         entity.getLorenzVec().let {
             if (it.distanceToPlayer() < 15) {
-                event.drawString(it.up(2.23), currentLabel)
+                drawString(it.up(2.23), currentLabel)
             }
         }
     }
 
-    private fun findMob(event: SkyHanniRenderWorldEvent): Boolean {
+    private fun SkyHanniRenderWorldEvent.findMob(): Boolean {
         if (!config.solver) return false
         if (TrevorSolver.mobLocation == TrapperMobArea.NONE) return false
 
@@ -315,25 +322,18 @@ object TrevorFeatures {
         if (found) {
             val displayName = TrevorSolver.currentMob?.mobName ?: "Mob Location"
             location = TrevorSolver.mobCoordinates
-            event.drawWaypointFilled(location.down(2), LorenzColor.GREEN.toColor(), seeThroughBlocks = true, beacon = true)
-            event.drawDynamicText(location.up(), displayName, 1.5)
+            drawWaypointFilled(location.down(2), LorenzColor.GREEN.toColor(), seeThroughBlocks = true, beacon = true)
+            drawDynamicText(location.up(), displayName, 1.5)
         } else {
-            event.drawWaypointFilled(location, LorenzColor.GOLD.toColor(), seeThroughBlocks = true, beacon = true)
-            event.drawDynamicText(location.up(), TrevorSolver.mobLocation.location, 1.5)
+            drawWaypointFilled(location, LorenzColor.GOLD.toColor(), seeThroughBlocks = true, beacon = true)
+            drawDynamicText(location.up(), TrevorSolver.mobLocation.location, 1.5)
         }
 
         return found
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        if (config.cooldown) renderCooldown(event)
-        val mobFound = findMob(event)
-        if (config.talbotCircles && !mobFound) TalbotCircles.drawCircles(event)
-    }
-
-    @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onKeyPress(event: KeyPressEvent) {
+    private fun onKeyPress(event: KeyPressEvent) {
         if (MinecraftCompat.screen != null) return
 
         if (event.keyCode != config.keyBind) return
@@ -356,7 +356,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
+    private fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!inTrapperDen || !config.cooldown) return
         if (clickArmorStandPattern.matches(event.entity.name.string)) event.cancel()
     }
@@ -372,12 +372,12 @@ object TrevorFeatures {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         resetTrapper()
     }
 
     @HandleEvent
-    fun onGraphAreaChange(event: GraphAreaChangeEvent) {
+    private fun onAreaChange(event: GraphAreaChangeEvent) {
         inTrapperDen = areaTrappersDenPattern.matches(event.area)
     }
 
@@ -392,7 +392,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val base = "misc.trevorTheTrapper"
         event.move(95, "$base.trapperSolver", "$base.solver")
         event.move(95, "$base.trapperMobDiedMessage", "$base.mobDiedMessage")
@@ -404,7 +404,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shcleartalbotcircles") {
             description = "Clears Talbot circles"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -43,8 +43,8 @@ object MatriarchHelper {
     private var exitNode: GraphNode? = null
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onMobSpawn(event: MobEvent.Spawn.Special) {
-        if (!isHeavyPearl(event)) return
+    private fun onMobSpawn(event: MobEvent.Spawn.Special) {
+        if (!event.isHeavyPearl()) return
         val node = IslandGraphs.findClosestNode(event.mob.baseEntity.getLorenzVec().up(1.2), { true })
         if (node == null) {
             ErrorManager.logErrorStateWithData(
@@ -67,11 +67,11 @@ object MatriarchHelper {
         }
     }
 
-    private fun isHeavyPearl(event: MobEvent) = isEnabled() && event.mob.name == "Heavy Pearl"
+    private fun MobEvent.isHeavyPearl() = isEnabled() && mob.name == "Heavy Pearl"
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onMobDespawn(event: MobEvent.DeSpawn.Special) {
-        if (!isHeavyPearl(event)) return
+    private fun onMobDespawn(event: MobEvent.DeSpawn.Special) {
+        if (!event.isHeavyPearl()) return
         pearlList.removeIf { it.first == event.mob }
     }
 
@@ -99,7 +99,7 @@ object MatriarchHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onTick() {
+    private fun onTick() {
         if (SkyBlockUtils.graphArea != AREA_NAME) return
         path.clear()
         path.addAll(accessPearls())
@@ -110,7 +110,7 @@ object MatriarchHelper {
     }
 
     @HandleEvent(GraphAreaChangeEvent::class, onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onGraphAreaChange() {
+    private fun onAreaChange() {
         if (SkyBlockUtils.graphArea != AREA_NAME) {
             tspCache = null
             lastTspPearls = 0
@@ -120,7 +120,7 @@ object MatriarchHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
         if (config.highlight) {
             val color = config.highlightColor
@@ -147,7 +147,7 @@ object MatriarchHelper {
     }
 
     @HandleEvent(IslandGraphReloadEvent::class)
-    fun onIslandGraphReload() {
+    private fun onIslandGraphReload() {
         exitNode = null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.config.features.rift.area.mountaintop.SunGeckoConfi
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
@@ -63,7 +62,6 @@ object SunGeckoHelper {
     private val sunGeckoActiveModifiers by patternGroup.pattern(
         "modifiers",
         "(?:§.)* {27}§r§c§lACTIVE MODIFIERS!",
-
     )
 
     private val sunGeckoChatLine by patternGroup.pattern(
@@ -145,7 +143,7 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onMobSpawn(event: MobEvent.Spawn) {
+    private fun onMobSpawn(event: MobEvent.Spawn) {
         val mob = event.mob
         val name = mob.name
         if (!name.contains("Sun Gecko")) return
@@ -171,7 +169,7 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onTick() {
+    private fun onTick() {
         if (!isEnabled() || !inTimeChamber) return
 
         updateDisplay()
@@ -192,14 +190,14 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onGuiRender(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay() {
         if (!isEnabled() || !inTimeChamber) return
 
         config.position.renderStrings(display, 0, "Sun Gecko Helper")
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!isEnabled()) return
         if (event.inventoryName != "Modifiers") return
         modifiers.clear()
@@ -213,7 +211,7 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onActionBar(event: ActionBarUpdateEvent) {
+    private fun onActionBar(event: ActionBarUpdateEvent) {
         if (!isEnabled()) return
         sunGeckoActionBar.findMatcher(event.actionBar) {
             val firstHalf = group("firstHalf")
@@ -251,7 +249,7 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
+    private fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
         if (!isEnabled()) return
         for (line in event.new) {
             if (line.startsWith(" Big damage in: §d")) {
@@ -262,7 +260,7 @@ object SunGeckoHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         if (sunGeckoActiveModifiers.matches(event.message)) {
             scanningChat = true
@@ -280,9 +278,9 @@ object SunGeckoHelper {
         }
     }
 
+    // Do not use GraphAreaChangeEvent here, Time Chamber has multiple locations
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onAreaChanged(event: ScoreboardAreaChangeEvent) {
-        // Do not use GraphAreaChangeEvent here, Time Chamber has multiple locations
+    private fun onScoreboardAreaChange(event: ScoreboardAreaChangeEvent) {
         if (!isEnabled()) return
         reset()
         inTimeChamber = event.area == "Time Chamber"

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -1,11 +1,11 @@
 package at.hannibal2.skyhanni.features.rift.area.westvillage
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
+import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
@@ -33,27 +33,27 @@ object VerminHighlighter {
     private val VERMIN_SPIDER_TEXTURE by SkullTextureHolder.texture("VERMIN_SPIDER")
 
     @HandleEvent
-    fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
+    private fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
         if (shouldDiscover()) tryAdd(event.entity)
     }
 
     @HandleEvent
-    fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent) {
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent) {
         if (shouldDiscover()) tryAdd(event.entity)
     }
 
     @HandleEvent
-    fun onEntityEnterWorld(event: EntityEnterWorldEvent<LivingEntity>) {
+    private fun onEntityEnterWorld(event: EntityEnterWorldEvent<LivingEntity>) {
         if (shouldDiscover()) tryAdd(event.entity)
     }
 
     @HandleEvent
-    fun onItemInHandChange(event: ItemInHandChangeEvent) {
+    private fun onItemInHandChange(event: ItemInHandChangeEvent) {
         if (event.newItem == TURBOMAX_VACUUM) refreshLoadedEntities()
     }
 
     @HandleEvent
-    fun onAreaChange(event: ScoreboardAreaChangeEvent) {
+    private fun onScoreboardAreaChange(event: ScoreboardAreaChangeEvent) {
         if (event.area == "West Village" || event.area == "Infested House") refreshLoadedEntities()
     }
 
@@ -64,7 +64,7 @@ object VerminHighlighter {
     }
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    private fun onConfigLoad() {
         ConditionalUtils.onToggle(config.color) {
             refreshLoadedEntities()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
-import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerProgressChangeEvent
 import at.hannibal2.skyhanni.features.inventory.CurrentEquipmentApi
 import at.hannibal2.skyhanni.features.misc.effects.NonGodPotEffectDisplay
@@ -122,12 +121,12 @@ object RemainingSlayerKills {
     private var killComboWisdom = 0
 
     @HandleEvent(priority = HIGHEST)
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         data = event.getConstant<SlayerData>("Slayer")
     }
 
     @HandleEvent(ProfileJoinEvent::class)
-    fun onProfileJoin() {
+    private fun onProfileJoin() {
         lastMissing = null
         lastMax = null
         lastReminder = SimpleTimeMark.farPast()
@@ -135,7 +134,7 @@ object RemainingSlayerKills {
     }
 
     @HandleEvent
-    fun onSlayerProgressChange(event: SlayerProgressChangeEvent) {
+    private fun onSlayerProgressChange(event: SlayerProgressChangeEvent) {
         if (!isEnabled()) return
 
         val progress = event.newProgress.removeColor()
@@ -149,14 +148,14 @@ object RemainingSlayerKills {
         update()
     }
 
-    @HandleEvent(GraphAreaChangeEvent::class)
-    fun onAreaChange() {
+    @HandleEvent
+    private fun onAreaChange() {
         if (!isEnabled()) return
         update()
     }
 
     @HandleEvent
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
+    private fun onSystemMessage(event: SystemMessageEvent.Allow) {
         val message = event.cleanMessage
         if (comboExpiredPattern.matches(message)) {
             killComboWisdom = 0


### PR DESCRIPTION
## What
Added a docs and primary function to the two area change events, fixed the listener names of their usages, and made all listeners in all related files private.

## Changelog Technical Details
+ Cleaned up Area Change Events.  - hannibal2