### PR TITLE
Fix: Minion Craft Helper not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
@@ -49,11 +49,13 @@ object MinionCraftHelper {
     )
 
     /**
-     * REGEX-TEST: Crafted Minions
+     * REGEX-TEST: (1/3) Crafted Minions
+     * REGEX-TEST: (2/3) Crafted Minions
+     * REGEX-TEST: (3/3) Crafted Minions
      */
     private val craftedMinionsInventoryPattern by patternGroup.pattern(
         "inventory",
-        "Crafted Minions",
+        "(?:\\(\\d/\\d\\) )?Crafted Minions",
     )
 
     private var display = emptyList<String>()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
@@ -227,8 +227,7 @@ class SkyblockGuideHighlightFeature private constructor(
             SkyblockGuideHighlightFeature(
                 { skyblockGuideConfig.minionGuide },
                 "minion",
-                // TODO: Not duplicate from MinionCraftHelper
-                "Crafted Minions",
+                "(?:\\(\\d/\\d\\) )?(?:Crafted Minions|\\w+ ➜ Minions)",
                 "§c ?✖.*|§7You haven't crafted this minion.",
             )
             SkyblockGuideHighlightFeature(


### PR DESCRIPTION
## What

The title was changed to include the current page at the beginning.

For the SkyBlock XP menu, I changed it to also work in /skyblockxp (not just /levels).

<details open>
<summary>Images</summary>

/craftedminions (or through /levels SkyBlock XP Menu -> Ways to Level Up)
<img width="329" height="219" alt="image" src="https://github.com/user-attachments/assets/e688582d-a319-493d-8737-27b209c3fe98" />
<br>
/skyblockxp Guide -> (Current Tier) -> Minions
<img width="334" height="226" alt="image" src="https://github.com/user-attachments/assets/abc5cc98-3e89-4acc-ac50-fce1cd86fe84" />

</details>

## Changelog Fixes
+ Fixed Minion Craft Helper and SkyBlock Guide Minion Highlight not working. - alex