### PR TITLE
Backend: Use ColoredBlockCompat everywhere

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.mining.OreBlock
-import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -375,7 +374,7 @@ object MiningApi {
 
         if (oldState == newState) return
         if (oldBlock == Blocks.AIR || oldBlock == Blocks.BEDROCK) return
-        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !isTitanium(newState)) return
+        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !OreBlock.isTitanium(newState)) return
 
         val pos = event.location
         if (pickobulusActive && pickobulusWaitingForBlock) {

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -47,7 +47,6 @@ import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.resources.Identifier
 import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.Item
-import net.minecraft.world.item.Items
 import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -37,6 +37,7 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.filterNotEmptyString
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
+import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.itemType
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -273,7 +274,7 @@ object ForagingBeaconSolver {
         NotificationManager.queueNotification(SkyHanniNotification(text, length = 5.seconds, showOverInventory = true))
     }
 
-    private fun SafeItemStack.isPaused(): Boolean = this.`is`(Items.RED_TERRACOTTA)
+    private fun SafeItemStack.isPaused(): Boolean = this.`is`(ColoredBlockCompat.RED.clayBlock.asItem())
 
     @HandleEvent
     fun onTick() {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -146,85 +146,85 @@ enum class OreBlock(
         fun getByStateOrNull(state: BlockState): OreBlock? = currentAreaOreBlocks.find { it.checkBlock(state) }
 
         fun getByNameOrNull(string: String) = entries.firstOrNull { it.name == string }
+
+        private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+            ColoredBlockCompat.GRAY.woolBlock,
+            ColoredBlockCompat.CYAN.clayBlock,
+        )
+
+        private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.PRISMARINE,
+            Blocks.PRISMARINE_BRICKS,
+            Blocks.DARK_PRISMARINE,
+        )
+
+        private fun isHighTierMithril(state: BlockState): Boolean =
+            state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
+
+        fun isTitanium(state: BlockState): Boolean =
+            state.block == Blocks.POLISHED_DIORITE
+
+        private fun isStone(state: BlockState): Boolean =
+            state.block == Blocks.STONE
+
+        private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
+            ColoredBlockCompat.GRAY.woolBlock,
+            ColoredBlockCompat.GREEN.woolBlock,
+            ColoredBlockCompat.CYAN.clayBlock,
+            ColoredBlockCompat.BROWN.clayBlock,
+            ColoredBlockCompat.GRAY.clayBlock,
+            ColoredBlockCompat.BLACK.clayBlock,
+            ColoredBlockCompat.LIME.clayBlock,
+            ColoredBlockCompat.GREEN.clayBlock,
+            ColoredBlockCompat.BLUE.clayBlock,
+            ColoredBlockCompat.RED.clayBlock,
+            ColoredBlockCompat.LIGHT_GRAY.clayBlock,
+            Blocks.CLAY,
+            Blocks.STONE_BRICKS,
+            Blocks.MOSSY_STONE_BRICKS,
+            Blocks.CRACKED_STONE_BRICKS,
+            Blocks.CHISELED_STONE_BRICKS,
+            Blocks.STONE,
+            Blocks.DIORITE,
+            Blocks.GRANITE,
+            Blocks.ANDESITE,
+        )
+
+        private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.INFESTED_STONE,
+            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+        )
+
+        private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.STONE,
+            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+        )
+
+        private fun isRedSand(state: BlockState): Boolean =
+            state.block == Blocks.RED_SAND
+
+        private fun isLowTierUmber(state: BlockState): Boolean =
+            state.block == Blocks.TERRACOTTA
+
+        private fun isMidTierUmber(state: BlockState): Boolean =
+            state.block == ColoredBlockCompat.BROWN.clayBlock
+
+        private fun isHighTierUmber(state: BlockState): Boolean =
+            state.block == Blocks.SMOOTH_RED_SANDSTONE
+
+        private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
+            state.block == Blocks.INFESTED_COBBLESTONE
+
+        private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.COBBLESTONE_SLAB,
+            Blocks.COBBLESTONE,
+            Blocks.COBBLESTONE_STAIRS,
+        )
+
+        private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
+            is StainedGlassBlock -> (block as StainedGlassBlock).color == color
+            is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
+            else -> false
+        }
     }
-}
-
-private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-    ColoredBlockCompat.GRAY.woolBlock,
-    ColoredBlockCompat.CYAN.clayBlock,
-)
-
-private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.PRISMARINE,
-    Blocks.PRISMARINE_BRICKS,
-    Blocks.DARK_PRISMARINE,
-)
-
-private fun isHighTierMithril(state: BlockState): Boolean =
-    state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
-
-fun isTitanium(state: BlockState): Boolean =
-    state.block == Blocks.POLISHED_DIORITE
-
-private fun isStone(state: BlockState): Boolean =
-    state.block == Blocks.STONE
-
-private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
-    ColoredBlockCompat.GRAY.woolBlock,
-    ColoredBlockCompat.GREEN.woolBlock,
-    ColoredBlockCompat.CYAN.clayBlock,
-    ColoredBlockCompat.BROWN.clayBlock,
-    ColoredBlockCompat.GRAY.clayBlock,
-    ColoredBlockCompat.BLACK.clayBlock,
-    ColoredBlockCompat.LIME.clayBlock,
-    ColoredBlockCompat.GREEN.clayBlock,
-    ColoredBlockCompat.BLUE.clayBlock,
-    ColoredBlockCompat.RED.clayBlock,
-    ColoredBlockCompat.LIGHT_GRAY.clayBlock,
-    Blocks.CLAY,
-    Blocks.STONE_BRICKS,
-    Blocks.MOSSY_STONE_BRICKS,
-    Blocks.CRACKED_STONE_BRICKS,
-    Blocks.CHISELED_STONE_BRICKS,
-    Blocks.STONE,
-    Blocks.DIORITE,
-    Blocks.GRANITE,
-    Blocks.ANDESITE,
-)
-
-private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.INFESTED_STONE,
-    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-)
-
-private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.STONE,
-    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-)
-
-private fun isRedSand(state: BlockState): Boolean =
-    state.block == Blocks.RED_SAND
-
-private fun isLowTierUmber(state: BlockState): Boolean =
-    state.block == Blocks.TERRACOTTA
-
-private fun isMidTierUmber(state: BlockState): Boolean =
-    state.block == ColoredBlockCompat.BROWN.clayBlock
-
-private fun isHighTierUmber(state: BlockState): Boolean =
-    state.block == Blocks.SMOOTH_RED_SANDSTONE
-
-private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
-    state.block == Blocks.INFESTED_COBBLESTONE
-
-private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.COBBLESTONE_SLAB,
-    Blocks.COBBLESTONE,
-    Blocks.COBBLESTONE_STAIRS,
-)
-
-private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
-    is StainedGlassBlock -> (block as StainedGlassBlock).color == color
-    is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
-    else -> false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.data.MiningApi.inSpidersDen
 import at.hannibal2.skyhanni.data.MiningApi.inTunnels
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
+import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import net.minecraft.world.item.DyeColor
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.Blocks
@@ -148,59 +149,58 @@ enum class OreBlock(
     }
 }
 
-private fun isLowTierMithril(state: BlockState): Boolean = when (state.block) {
-    Blocks.GRAY_WOOL -> true
-    Blocks.CYAN_TERRACOTTA -> true
-    else -> false
-}
+private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+    ColoredBlockCompat.GRAY.woolBlock,
+    ColoredBlockCompat.CYAN.clayBlock,
+)
 
-private fun isMidTierMithril(state: BlockState): Boolean {
-    return state.block == Blocks.PRISMARINE || state.block == Blocks.PRISMARINE_BRICKS || state.block == Blocks.DARK_PRISMARINE
-}
+private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.PRISMARINE,
+    Blocks.PRISMARINE_BRICKS,
+    Blocks.DARK_PRISMARINE,
+)
 
-private fun isHighTierMithril(state: BlockState): Boolean {
-    return state.block == Blocks.LIGHT_BLUE_WOOL
-}
+private fun isHighTierMithril(state: BlockState): Boolean =
+    state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
 
-fun isTitanium(state: BlockState): Boolean {
-    return state.block == Blocks.POLISHED_DIORITE
-}
+fun isTitanium(state: BlockState): Boolean =
+    state.block == Blocks.POLISHED_DIORITE
 
-private fun isStone(state: BlockState): Boolean {
-    return state.block == Blocks.STONE
-}
+private fun isStone(state: BlockState): Boolean =
+    state.block == Blocks.STONE
 
-private fun isHardStoneHollows(state: BlockState): Boolean {
-    return when (state.block) {
-        Blocks.GRAY_WOOL -> true
-        Blocks.GREEN_WOOL -> true
-        Blocks.CYAN_TERRACOTTA -> true
-        Blocks.BROWN_TERRACOTTA -> true
-        Blocks.GRAY_TERRACOTTA -> true
-        Blocks.BLACK_TERRACOTTA -> true
-        Blocks.LIME_TERRACOTTA -> true
-        Blocks.GREEN_TERRACOTTA -> true
-        Blocks.BLUE_TERRACOTTA -> true
-        Blocks.RED_TERRACOTTA -> true
-        Blocks.LIGHT_GRAY_TERRACOTTA -> true
-        Blocks.CLAY -> true
-        Blocks.STONE_BRICKS -> true
-        Blocks.MOSSY_STONE_BRICKS -> true
-        Blocks.CRACKED_STONE_BRICKS -> true
-        Blocks.CHISELED_STONE_BRICKS -> true
-        Blocks.STONE -> true
-        Blocks.DIORITE -> true
-        Blocks.GRANITE -> true
-        Blocks.ANDESITE -> true
-        else -> false
-    }
-}
+private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
+    ColoredBlockCompat.GRAY.woolBlock,
+    ColoredBlockCompat.GREEN.woolBlock,
+    ColoredBlockCompat.CYAN.clayBlock,
+    ColoredBlockCompat.BROWN.clayBlock,
+    ColoredBlockCompat.GRAY.clayBlock,
+    ColoredBlockCompat.BLACK.clayBlock,
+    ColoredBlockCompat.LIME.clayBlock,
+    ColoredBlockCompat.GREEN.clayBlock,
+    ColoredBlockCompat.BLUE.clayBlock,
+    ColoredBlockCompat.RED.clayBlock,
+    ColoredBlockCompat.LIGHT_GRAY.clayBlock,
+    Blocks.CLAY,
+    Blocks.STONE_BRICKS,
+    Blocks.MOSSY_STONE_BRICKS,
+    Blocks.CRACKED_STONE_BRICKS,
+    Blocks.CHISELED_STONE_BRICKS,
+    Blocks.STONE,
+    Blocks.DIORITE,
+    Blocks.GRANITE,
+    Blocks.ANDESITE,
+)
 
-private fun isHardstoneTunnels(state: BlockState): Boolean =
-    state.block == Blocks.INFESTED_STONE || state.block == Blocks.LIGHT_GRAY_WOOL
+private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.INFESTED_STONE,
+    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+)
 
-private fun isHardstoneMineshaft(state: BlockState): Boolean =
-    state.block == Blocks.STONE || state.block == Blocks.LIGHT_GRAY_WOOL
+private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.STONE,
+    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+)
 
 private fun isRedSand(state: BlockState): Boolean =
     state.block == Blocks.RED_SAND
@@ -209,7 +209,7 @@ private fun isLowTierUmber(state: BlockState): Boolean =
     state.block == Blocks.TERRACOTTA
 
 private fun isMidTierUmber(state: BlockState): Boolean =
-    state.block == Blocks.BROWN_TERRACOTTA
+    state.block == ColoredBlockCompat.BROWN.clayBlock
 
 private fun isHighTierUmber(state: BlockState): Boolean =
     state.block == Blocks.SMOOTH_RED_SANDSTONE
@@ -217,11 +217,11 @@ private fun isHighTierUmber(state: BlockState): Boolean =
 private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
     state.block == Blocks.INFESTED_COBBLESTONE
 
-private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = when (state.block) {
-    Blocks.COBBLESTONE_SLAB -> true
-    Blocks.COBBLESTONE, Blocks.COBBLESTONE_STAIRS -> true
-    else -> false
-}
+private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.COBBLESTONE_SLAB,
+    Blocks.COBBLESTONE,
+    Blocks.COBBLESTONE_STAIRS,
+)
 
 private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
     is StainedGlassBlock -> (block as StainedGlassBlock).color == color

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -27,6 +27,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.UtilsPatterns
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
@@ -49,7 +50,7 @@ object UserLuckBreakdown {
     private const val MAIN_LUCK_NAME = "§a✴ SkyHanni User Luck"
 
     private var fillerItem: SafeItemStack? = null
-    private val fillerID = Blocks.BLACK_STAINED_GLASS_PANE.asItem()
+    private val fillerID = ColoredBlockCompat.BLACK.glassPaneBlock.asItem()
 
     private var showAllStats = true
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -33,7 +33,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import net.minecraft.world.SimpleContainer
 import net.minecraft.world.item.Items
-import net.minecraft.world.level.block.Blocks
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/ColoredBlockCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/ColoredBlockCompat.kt
@@ -20,10 +20,10 @@ import net.minecraft.world.level.block.state.BlockState
 enum class ColoredBlockCompat(
     private val metaColor: Int,
     private val color: LorenzColor,
-    private val glassBlock: Block,
-    private val glassPaneBlock: Block,
-    private val woolBlock: Block,
-    private val clayBlock: Block,
+    val glassBlock: Block,
+    val glassPaneBlock: Block,
+    val woolBlock: Block,
+    val clayBlock: Block,
 ) {
     WHITE(
         0,

--- a/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.features.garden.visitor.VisitorReward
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import net.minecraft.world.item.Items
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -41,7 +42,7 @@ class GardenVisitorTooltipTest {
 
     @Test
     fun `visitor tooltip parses copper line and rare reward with heart suffix`() {
-        val offerItem = ItemUtils.createItemStack(Items.GREEN_TERRACOTTA, "§aAccept Offer", spacemanLore)
+        val offerItem = ItemUtils.createItemStack(ColoredBlockCompat.GREEN.clayBlock.asItem(), "§aAccept Offer", spacemanLore)
         val visitor = VisitorApi.Visitor(
             visitorName = "§cSpaceman",
             status = VisitorApi.VisitorStatus.NEW,


### PR DESCRIPTION
## What
Exposes some fields from `ColoredBlockCompat` and uses them everywhere instead of the vanilla constants, as they're changing in 26.2.

## Changelog Technical Details
+ Switched from vanilla Blocks/Items constants to ColoredBlockCompat where possible. - Luna