### PR TITLE
 Fix: Snoozed reminders sometimes not showing on screen

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -137,6 +137,7 @@ object ReminderManager {
     ) { arguments, reminder ->
         val time = parseDuration(arguments.first()) ?: return@actionReminder "§cInvalid time format!"
         reminder.remindAt = SimpleTimeMark.now().plus(time)
+        reminder.lastReminder = SimpleTimeMark.farPast()
         "§6Reminder moved to ${time.format()}"
     }
 


### PR DESCRIPTION
## What
Snoozing a reminder (with the ⟳ button or `/shremind move`) could leave it silent when the snooze timer was up (no title, sound, or chat message would show until much later). This happened whenever the snooze was shorter than the reminder interval. Snoozed reminders now reliably show up right when their timer ends.

## Changelog Fixes
+ Fixed snoozed reminders sometimes not showing up on screen when the timer was up. - RemainingDelta