### PR TITLE
Fix: Make LocationUtils.playerLocation null-safe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/PhantomleafSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/PhantomleafSolver.kt
@@ -8,8 +8,8 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.find
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -77,7 +77,7 @@ object PhantomleafSolver {
         if (event.pitch !in MINIMUM_ALLOWED_PITCH..MAXIMUM_ALLOWED_PITCH) return
         if (event.soundName != "block.note_block.basedrum") return
 
-        val currentPos = PlayerUtils.getLocation()
+        val currentPos = LocationUtils.playerLocation()
 
         if (lastPos?.equalsIgnoreY(currentPos) ?: false) {
             val dist = HYPIXEL_VOLUME_SCALING_FACTOR * (1.0 - event.volume)

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -30,7 +30,15 @@ object LocationUtils {
 
     private fun canSee0(a: LorenzVec, b: LorenzVec): Boolean = BlockUtils.raycast(a, b).miss
 
-    fun playerLocation() = PlayerUtils.getLocation()
+    /**
+     * Returns the player's current location, or null if the player does not exist.
+     */
+    fun playerLocationOrNull(): LorenzVec? = MinecraftCompat.localPlayerOrNull?.getLorenzVec()
+
+    /**
+     * Returns the player's current location, or LorenzVec(0.0, 0.0, 0.0) if the player does not exist.
+     */
+    fun playerLocation(): LorenzVec = playerLocationOrNull() ?: LorenzVec()
 
     // Block heights are multiples of 1/16, so we subtract 1/16 to find the right block
     fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundToBlock()

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -56,7 +56,5 @@ object PlayerUtils {
 
     fun blockPosition() = MinecraftCompat.localPlayerOrThrow.blockPosition().toLorenzVec()
 
-    fun getLocation() = MinecraftCompat.localPlayerOrThrow.getLorenzVec()
-
     fun isSneaking(): Boolean = MinecraftCompat.localPlayerOrThrow.isShiftKeyDown
 }


### PR DESCRIPTION
## What
Instead of throwing an exception, return `LorenzVec(0.0, 0.0, 0.0)` if we have no player. Also added `LocationUtils.playerLocationOrNull` for any potential future callers that want to make sure they're not inadvertently getting a fake zero value.

## Changelog Fixes
+ Fixed an error when switching lobbies while a SkyHanni feature is trying to get your location. - Luna

## Changelog Technical Details
+ Changed LocationUtils.playerLocation to return a fallback value of LorenzVec(0.0, 0.0, 0.0) instead of throwing if the player is null. - Luna
+ Added LocationUtils.playerLocationOrNull. - Luna
+ Removed PlayerUtils.getLocation (only had one use outside the LocationUtils wrapper). - Luna