### PR TITLE
Improvement: Add configurable underbid amount to Copy Underbid Price

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHouseConfig.kt
@@ -8,6 +8,7 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import org.lwjgl.glfw.GLFW
 
@@ -54,7 +55,7 @@ class AuctionHouseConfig {
     @ConfigOption(
         name = "Auto Copy Underbid",
         desc = "Automatically copies the price of an item in the \"Create BIN Auction\"" +
-            " minus 1 coin into the clipboard for faster under-bidding."
+            " minus the §eUnderbid Amount §7into the clipboard for faster under-bidding."
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -63,10 +64,20 @@ class AuctionHouseConfig {
     @Expose
     @ConfigOption(
         name = "Copy Underbid Keybind",
-        desc = "Copy the price of the hovered item in Auction House minus 1 coin into the clipboard for easier under-bidding."
+        desc = "Copy the price of the hovered item in Auction House minus the §eUnderbid Amount " +
+            "§7into the clipboard for easier under-bidding."
     )
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
     var copyUnderbidKeybind: Int = GLFW.GLFW_KEY_UNKNOWN
+
+    @Expose
+    @ConfigOption(
+        name = "Underbid Amount",
+        desc = "How many coins to subtract from the price when copying an underbid. " +
+            "Supports shorthand like §e1k§7. Default §e1§7."
+    )
+    @ConfigEditorText
+    var underbidAmount: String = "1"
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrNull
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -82,7 +83,9 @@ object AuctionHouseCopyUnderbidPrice {
     }
 
     private fun copyPrice(price: Long) {
-        val underbidPrice = price - 1
+        val amount = config.underbidAmount.formatLongOrNull() ?: 1L
+        // Underbid by the configured amount, falling back to 1 coin if that's negative or would zero out the price.
+        val underbidPrice = if (amount < 0 || amount >= price) price - 1 else price - amount
         OSUtils.copyToClipboard("$underbidPrice")
         ChatUtils.chat(
             "Copied ${underbidPrice.addSeparators()} to clipboard. (Copy Underbid Price)",


### PR DESCRIPTION
## What
Adds a new "Underbid Amount" setting to the Copy Underbid Price feature, letting you choose how many coins to subtract when copying an underbid instead of always using 1. Supports shorthand like `1k`. Both the auto-copy (in Create BIN Auction) and the hover keybind use it. Invalid or negative values, or amounts that would drop the price to zero or below, fall back to underbidding by 1.

<details>
<summary>Images</summary>

Config: Inventory -> Auction House
<img width="1016" height="814" alt="Categories" src="https://github.com/user-attachments/assets/9672afa7-734f-4082-bef3-e2084b86c064" />


</details>

## Changelog Improvements
+ Added an option to choose how many coins to underbid by when copying an underbid price. - RemainingDelta
  
