### PR TITLE
Fix: Last minute changes

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -208,6 +208,7 @@
       <w>hina</w>
       <w>hitbox</w>
       <w>hitman</w>
+      <w>honeyhive</w>
       <w>hootie</w>
       <w>hoppity</w>
       <w>hoppity's</w>

--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
@@ -47,7 +47,7 @@ object ReforgeApi {
         SWORD_AND_ROD(ItemCategory.SWORD, ItemCategory.GAUNTLET, ItemCategory.LONGSWORD, ItemCategory.FISHING_ROD),
         SPECIAL_ITEMS,
         VACUUM(ItemCategory.VACUUM),
-        FISHING_NET(ItemCategory.FISHING_NET)
+        FISHING_NET(ItemCategory.FISHING_NET),
     }
 
     sealed interface ReforgeData {

--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
@@ -47,6 +47,7 @@ object ReforgeApi {
         SWORD_AND_ROD(ItemCategory.SWORD, ItemCategory.GAUNTLET, ItemCategory.LONGSWORD, ItemCategory.FISHING_ROD),
         SPECIAL_ITEMS,
         VACUUM(ItemCategory.VACUUM),
+        FISHING_NET(ItemCategory.FISHING_NET)
     }
 
     sealed interface ReforgeData {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -169,11 +169,11 @@ enum class GraphNodeTag(
         onlyIslands = IslandTypeTag.FORAGING_CUSTOM_TREES,
     ),
 
-    HONEY_HIVE(
-        "honey_hive",
+    HONEYHIVE(
+        "honeyhive",
         LorenzColor.GOLD,
-        "Honey Hive",
-        "Lootable Honey Hive.",
+        "Honeyhive",
+        "Lootable Honeyhive.",
         onlyIsland = IslandType.TORRHUS_CANYON,
     ),
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -34,7 +34,7 @@ object NavigateAllHelper {
         GraphNodeTag.HIDEONLEAF,
         GraphNodeTag.HIDEONSUN,
         GraphNodeTag.TREE_PROTECTION_ORDER,
-        GraphNodeTag.HONEY_HIVE,
+        GraphNodeTag.HONEYHIVE,
         GraphNodeTag.SAFARI_BELL,
         GraphNodeTag.HIDEYHO_LOCATION,
     )


### PR DESCRIPTION
## What
Fishing nets now can be reforged. Also the honeyhives are not two words but that is not user facing.

## Changelog Fixes
+ Fixed Reforge Helper not working with Fishing Nets. - CalMWolfs
