### PR TITLE
Fix: Update Foraging & Hunting level caps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillType.kt
@@ -17,7 +17,7 @@ enum class SkillType(val displayName: String, icon: Item, val maxLevel: Int) {
     ALCHEMY("Alchemy", Items.BREWING_STAND, 50),
     CARPENTRY("Carpentry", Blocks.CRAFTING_TABLE, 50),
     TAMING("Taming", Items.POLAR_BEAR_SPAWN_EGG, 60),
-    HUNTING("Hunting", Items.LEAD, 25),
+    HUNTING("Hunting", Items.LEAD, 50),
     ;
 
     constructor(displayName: String, block: Block, maxLevel: Int) : this(displayName, block.asItem(), maxLevel)

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillType.kt
@@ -12,7 +12,7 @@ enum class SkillType(val displayName: String, icon: Item, val maxLevel: Int) {
     FARMING("Farming", Items.GOLDEN_HOE, 60),
     FISHING("Fishing", Items.FISHING_ROD, 50),
     MINING("Mining", Items.GOLDEN_PICKAXE, 60),
-    FORAGING("Foraging", Items.GOLDEN_AXE, 54),
+    FORAGING("Foraging", Items.GOLDEN_AXE, 57),
     ENCHANTING("Enchanting", Blocks.ENCHANTING_TABLE, 60),
     ALCHEMY("Alchemy", Items.BREWING_STAND, 50),
     CARPENTRY("Carpentry", Blocks.CRAFTING_TABLE, 50),


### PR DESCRIPTION
## What
SkyBlock 0.27 added Foraging levels 55–57 and Hunting levels 26–50, we forgot about this.

## Changelog Fixes
+ Fixed the mod thinking the max Foraging level is still 54 instead of 57. - Luna
+ Fixed the mod thinking the max Hunting level is still 25 instead of 50. - Luna