### PR TITLE
Fix: Safari -> Critter Safari

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -53,7 +53,7 @@ enum class IslandType(private val nameFallback: String, private val apiNameFallb
 
     // Special
     THE_RIFT("The Rift", "rift"),
-    SAFARI("Safari", "safari"),
+    SAFARI("Critter Safari", "safari"),
 
     // Special values
     NONE("", null),


### PR DESCRIPTION
## What
Was a late-ish change on alpha. (Why is this data duplicated in code when it's already in the repo?)

<details>
<summary>Images</summary>

<img width="267" height="250" alt="2026-08-04_23-13-45" src="https://github.com/user-attachments/assets/10dc437c-7a87-4e49-a3dd-b1cdc484b580" />

</details>

## Changelog Fixes
+ Fixed SkyHanni saying "Safari" instead of "Critter Safari". - Luna