### PR TITLE
Backend: Add new Minecraft console filters

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
@@ -127,4 +127,12 @@ class ConsoleFiltersConfig {
     )
     @ConfigEditorBoolean
     var filterExistingTeam: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Filter Chunk Sections UBO",
+        desc = "Filter 'Resizing Chunk Sections UBO' messages.",
+    )
+    @ConfigEditorBoolean
+    var filterChunkSectionsUbo: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
@@ -95,4 +95,20 @@ class ConsoleFiltersConfig {
     @ConfigOption(name = "Filter Unknown Team Packet", desc = "Filter 'Received packet for unknown team' warnings during server changes.")
     @ConfigEditorBoolean
     var filterUnknownTeam: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Filter Unknown Passengers",
+        desc = "Filter 'Received passengers for unknown entity' warnings.",
+    )
+    @ConfigEditorBoolean
+    var filterUnknownPassengers: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Filter Missing Texture References",
+        desc = "Filter 'Missing texture references in model' warnings from Hypixel resource packs.",
+    )
+    @ConfigEditorBoolean
+    var filterMissingTextureReferences: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/minecraftconsole/ConsoleFiltersConfig.kt
@@ -111,4 +111,20 @@ class ConsoleFiltersConfig {
     )
     @ConfigEditorBoolean
     var filterMissingTextureReferences: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Filter Atlas Created",
+        desc = "Filter 'Created: <size> <name>-atlas' messages during texture atlas stitching.",
+    )
+    @ConfigEditorBoolean
+    var filterAtlasCreated: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Filter Existing Team",
+        desc = "Filter 'Requested creation of existing team' warnings.",
+    )
+    @ConfigEditorBoolean
+    var filterExistingTeam: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -184,6 +184,21 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFil
             return Filter.Result.DENY
         }
 
+        if (filterConfig.filterAtlasCreated &&
+            formattedMessage.startsWith("Created: ") &&
+            formattedMessage.endsWith("-atlas")
+        ) {
+            filterConsole("texture atlas created")
+            return Filter.Result.DENY
+        }
+
+        if (filterConfig.filterExistingTeam &&
+            formattedMessage.startsWith("Requested creation of existing team ")
+        ) {
+            filterConsole("existing team creation")
+            return Filter.Result.DENY
+        }
+
         if (filterScoreboardErrors(event)) return Filter.Result.DENY
 
         if (!config.printUnfilteredDebugs) return Filter.Result.ACCEPT

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -170,6 +170,20 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFil
             return Filter.Result.DENY
         }
 
+        if (filterConfig.filterUnknownPassengers &&
+            formattedMessage == "Received passengers for unknown entity"
+        ) {
+            filterConsole("unknown entity passengers")
+            return Filter.Result.DENY
+        }
+
+        if (filterConfig.filterMissingTextureReferences &&
+            formattedMessage.startsWith("Missing texture references in model ")
+        ) {
+            filterConsole("missing texture references")
+            return Filter.Result.DENY
+        }
+
         if (filterScoreboardErrors(event)) return Filter.Result.DENY
 
         if (!config.printUnfilteredDebugs) return Filter.Result.ACCEPT

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -199,6 +199,13 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFil
             return Filter.Result.DENY
         }
 
+        if (filterConfig.filterChunkSectionsUbo &&
+            formattedMessage.startsWith("Resizing Chunk Sections UBO")
+        ) {
+            filterConsole("chunk sections UBO resize")
+            return Filter.Result.DENY
+        }
+
         if (filterScoreboardErrors(event)) return Filter.Result.DENY
 
         if (!config.printUnfilteredDebugs) return Filter.Result.ACCEPT


### PR DESCRIPTION
## Changelog Technical Details
+ Added console filters for five more spam messages. - hannibal2
    + Received passengers for unknown entity.
    + Missing texture references in model.
    + Created: `<name>`-atlas.
    + Requested creation of existing team.
    + Resizing Chunk Sections UBO.