### PR TITLE
Fix: Use null safe level accessor in EntityEvents

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/EntityEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/EntityEvents.kt
@@ -17,7 +17,7 @@ object EntityEvents {
     fun onPacketReceived(event: PacketReceivedEvent) {
         val packet = event.packet as? ClientboundHurtAnimationPacket ?: return
 
-        val entity = MinecraftCompat.localWorldOrThrow.getEntity(packet.id()) ?: return
+        val entity = MinecraftCompat.localWorldOrNull?.getEntity(packet.id()) ?: return
         EntityHurtEvent(entity, DamageSourceCompat.generic, 0.0f).post()
 
         val skyblockMob = MobData.entityToMob[entity] ?: return


### PR DESCRIPTION
## What
Fixes this:
```
SkyHanni 7.42.0 1.21.11: Caught a IllegalStateException in at.hannibal2.skyhanni.api.minecraftevents.EntityEvents.onPacketReceived(at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent) at PacketReceivedEvent: level is null
 
Caused by java.lang.IllegalStateException: level is null
    at SH.utils.compat.MinecraftCompat.getLocalWorldOrThrow(MinecraftCompat.kt:33)
    at SH.api.minecraftevents.EntityEvents.onPacketReceived(EntityEvents.kt:20)
<SkyHanni event post>
```

## Changelog Fixes
+ Fixed a rare error when an entity gets damaged just as you switch lobbies. - Luna