### PR TITLE
Fix: Crash/error when checking blocks against OreBlock entries

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.mining.OreBlock
+import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -374,7 +375,7 @@ object MiningApi {
 
         if (oldState == newState) return
         if (oldBlock == Blocks.AIR || oldBlock == Blocks.BEDROCK) return
-        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !OreBlock.isTitanium(newState)) return
+        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !isTitanium(newState)) return
 
         val pos = event.location
         if (pickobulusActive && pickobulusWaitingForBlock) {

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.mining.OreBlock
-import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -375,7 +374,7 @@ object MiningApi {
 
         if (oldState == newState) return
         if (oldBlock == Blocks.AIR || oldBlock == Blocks.BEDROCK) return
-        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !isTitanium(newState)) return
+        if (newBlock != Blocks.AIR && newBlock != Blocks.BEDROCK && !OreBlock.isTitanium(newState)) return
 
         val pos = event.location
         if (pickobulusActive && pickobulusWaitingForBlock) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -36,15 +36,15 @@ enum class OreBlock(
     val hasInitSound: Boolean = true,
 ) {
     // MITHRIL
-    LOW_TIER_MITHRIL(::isLowTierMithril, { inDwarvenMines || inGlacite }, OreCategory.DWARVEN_METAL),
-    MID_TIER_MITHRIL(::isMidTierMithril, { inDwarvenMines || inCrystalHollows || inGlacite }, OreCategory.DWARVEN_METAL),
-    HIGH_TIER_MITHRIL(::isHighTierMithril, { inDwarvenMines || inCrystalHollows || inGlacite }, OreCategory.DWARVEN_METAL),
+    LOW_TIER_MITHRIL({ isLowTierMithril(it) }, { inDwarvenMines || inGlacite }, OreCategory.DWARVEN_METAL),
+    MID_TIER_MITHRIL({ isMidTierMithril(it) }, { inDwarvenMines || inCrystalHollows || inGlacite }, OreCategory.DWARVEN_METAL),
+    HIGH_TIER_MITHRIL({ isHighTierMithril(it) }, { inDwarvenMines || inCrystalHollows || inGlacite }, OreCategory.DWARVEN_METAL),
 
     // TITANIUM
-    TITANIUM(::isTitanium, { inDwarvenMines || inGlacite }, OreCategory.DWARVEN_METAL),
+    TITANIUM({ isTitanium(it) }, { inDwarvenMines || inGlacite }, OreCategory.DWARVEN_METAL),
 
     // VANILLA ORES
-    STONE(::isStone, { inDwarvenMines }, OreCategory.BLOCK),
+    STONE({ isStone(it) }, { inDwarvenMines }, OreCategory.BLOCK),
     COBBLESTONE(Blocks.COBBLESTONE, { inDwarvenMines }, OreCategory.BLOCK),
     COAL_ORE(Blocks.COAL_ORE, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE),
     IRON_ORE(Blocks.IRON_ORE, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE),
@@ -63,7 +63,7 @@ enum class OreBlock(
     QUARTZ_ORE(Blocks.NETHER_QUARTZ_ORE, { inCrystalHollows || inCrimsonIsle }, OreCategory.ORE),
     GLOWSTONE(Blocks.GLOWSTONE, { inCrimsonIsle }, OreCategory.BLOCK),
     MYCELIUM(Blocks.MYCELIUM, { inCrimsonIsle }, OreCategory.BLOCK),
-    RED_SAND(::isRedSand, { inCrimsonIsle }, OreCategory.BLOCK),
+    RED_SAND({ isRedSand(it) }, { inCrimsonIsle }, OreCategory.BLOCK),
     SULPHUR(Blocks.SPONGE, { inCrimsonIsle }, OreCategory.ORE),
 
     // SPIDER'S DEN
@@ -74,9 +74,9 @@ enum class OreBlock(
     OBSIDIAN(Blocks.OBSIDIAN, { inCrystalHollows || inMineshaft || inEnd }, OreCategory.ORE),
 
     // HARD STONE
-    HARD_STONE_HOLLOWS(::isHardStoneHollows, { inCrystalHollows }, OreCategory.BLOCK),
-    HARD_STONE_TUNNELS(::isHardstoneTunnels, { inTunnels }, OreCategory.BLOCK),
-    HARD_STONE_MINESHAFT(::isHardstoneMineshaft, { inMineshaft }, OreCategory.BLOCK),
+    HARD_STONE_HOLLOWS({ isHardStoneHollows(it) }, { inCrystalHollows }, OreCategory.BLOCK),
+    HARD_STONE_TUNNELS({ isHardstoneTunnels(it) }, { inTunnels }, OreCategory.BLOCK),
+    HARD_STONE_MINESHAFT({ isHardstoneMineshaft(it) }, { inMineshaft }, OreCategory.BLOCK),
 
     // DWARVEN BLOCKS
     PURE_COAL(Blocks.COAL_BLOCK, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE),
@@ -107,12 +107,12 @@ enum class OreBlock(
     PERIDOT(DyeColor.GREEN, { inGlacite }, OreCategory.GEMSTONE),
 
     // GLACIAL
-    LOW_TIER_UMBER(::isLowTierUmber, { inGlacite }, OreCategory.DWARVEN_METAL),
-    MID_TIER_UMBER(::isMidTierUmber, { inGlacite }, OreCategory.DWARVEN_METAL),
-    HIGH_TIER_UMBER(::isHighTierUmber, { inGlacite }, OreCategory.DWARVEN_METAL),
+    LOW_TIER_UMBER({ isLowTierUmber(it) }, { inGlacite }, OreCategory.DWARVEN_METAL),
+    MID_TIER_UMBER({ isMidTierUmber(it) }, { inGlacite }, OreCategory.DWARVEN_METAL),
+    HIGH_TIER_UMBER({ isHighTierUmber(it) }, { inGlacite }, OreCategory.DWARVEN_METAL),
 
-    LOW_TIER_TUNGSTEN_TUNNELS(::isLowTierTungstenTunnels, { inTunnels }, OreCategory.DWARVEN_METAL),
-    LOW_TIER_TUNGSTEN_MINESHAFT(::isLowTierTungstenMineshaft, { inMineshaft }, OreCategory.DWARVEN_METAL),
+    LOW_TIER_TUNGSTEN_TUNNELS({ isLowTierTungstenTunnels(it) }, { inTunnels }, OreCategory.DWARVEN_METAL),
+    LOW_TIER_TUNGSTEN_MINESHAFT({ isLowTierTungstenMineshaft(it) }, { inMineshaft }, OreCategory.DWARVEN_METAL),
     HIGH_TIER_TUNGSTEN(Blocks.CLAY, { inGlacite }, OreCategory.DWARVEN_METAL),
 
     GLACITE(Blocks.PACKED_ICE, { inGlacite }, OreCategory.DWARVEN_METAL),
@@ -142,92 +142,94 @@ enum class OreBlock(
     constructor(gemstoneColor: DyeColor, checkArea: () -> Boolean, category: OreCategory, hasInitSound: Boolean = true) :
         this({ it.isGemstoneWithColor(gemstoneColor) }, checkArea, category, hasInitSound)
 
+    @Suppress("TooManyFunctions")
     companion object {
         fun getByStateOrNull(state: BlockState): OreBlock? = currentAreaOreBlocks.find { it.checkBlock(state) }
 
-        fun getByNameOrNull(string: String) = entries.firstOrNull { it.name == string }
+        fun getByNameOrNull(string: String): OreBlock? = entries.firstOrNull { it.name == string }
+
+        // The enum entries must call these checks through a lambda, never through a method reference.
+        // A method reference to a companion member captures the companion instance when the reference is created,
+        // which happens while the enum entries are being initialized, before the companion instance exists.
+        // A lambda resolves the companion at call time instead, which is safe.
+        private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+            ColoredBlockCompat.GRAY.woolBlock,
+            ColoredBlockCompat.CYAN.clayBlock,
+        )
+
+        private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.PRISMARINE,
+            Blocks.PRISMARINE_BRICKS,
+            Blocks.DARK_PRISMARINE,
+        )
+
+        private fun isHighTierMithril(state: BlockState): Boolean =
+            state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
+
+        fun isTitanium(state: BlockState): Boolean =
+            state.block == Blocks.POLISHED_DIORITE
+
+        private fun isStone(state: BlockState): Boolean =
+            state.block == Blocks.STONE
+
+        private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
+            ColoredBlockCompat.GRAY.woolBlock,
+            ColoredBlockCompat.GREEN.woolBlock,
+            ColoredBlockCompat.CYAN.clayBlock,
+            ColoredBlockCompat.BROWN.clayBlock,
+            ColoredBlockCompat.GRAY.clayBlock,
+            ColoredBlockCompat.BLACK.clayBlock,
+            ColoredBlockCompat.LIME.clayBlock,
+            ColoredBlockCompat.GREEN.clayBlock,
+            ColoredBlockCompat.BLUE.clayBlock,
+            ColoredBlockCompat.RED.clayBlock,
+            ColoredBlockCompat.LIGHT_GRAY.clayBlock,
+            Blocks.CLAY,
+            Blocks.STONE_BRICKS,
+            Blocks.MOSSY_STONE_BRICKS,
+            Blocks.CRACKED_STONE_BRICKS,
+            Blocks.CHISELED_STONE_BRICKS,
+            Blocks.STONE,
+            Blocks.DIORITE,
+            Blocks.GRANITE,
+            Blocks.ANDESITE,
+        )
+
+        private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.INFESTED_STONE,
+            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+        )
+
+        private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.STONE,
+            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+        )
+
+        private fun isRedSand(state: BlockState): Boolean =
+            state.block == Blocks.RED_SAND
+
+        private fun isLowTierUmber(state: BlockState): Boolean =
+            state.block == Blocks.TERRACOTTA
+
+        private fun isMidTierUmber(state: BlockState): Boolean =
+            state.block == ColoredBlockCompat.BROWN.clayBlock
+
+        private fun isHighTierUmber(state: BlockState): Boolean =
+            state.block == Blocks.SMOOTH_RED_SANDSTONE
+
+        private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
+            state.block == Blocks.INFESTED_COBBLESTONE
+
+        private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+            Blocks.COBBLESTONE_SLAB,
+            Blocks.COBBLESTONE,
+            Blocks.COBBLESTONE_STAIRS,
+        )
+
+        private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
+            is StainedGlassBlock -> (block as StainedGlassBlock).color == color
+            is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
+            else -> false
+        }
     }
-}
-
-// The block checks below must stay top level. The entries reference them while the enum is being initialised, which is
-// before the companion object instance exists, so a reference to a companion member would capture a null receiver.
-
-private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-    ColoredBlockCompat.GRAY.woolBlock,
-    ColoredBlockCompat.CYAN.clayBlock,
-)
-
-private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.PRISMARINE,
-    Blocks.PRISMARINE_BRICKS,
-    Blocks.DARK_PRISMARINE,
-)
-
-private fun isHighTierMithril(state: BlockState): Boolean =
-    state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
-
-fun isTitanium(state: BlockState): Boolean =
-    state.block == Blocks.POLISHED_DIORITE
-
-private fun isStone(state: BlockState): Boolean =
-    state.block == Blocks.STONE
-
-private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
-    ColoredBlockCompat.GRAY.woolBlock,
-    ColoredBlockCompat.GREEN.woolBlock,
-    ColoredBlockCompat.CYAN.clayBlock,
-    ColoredBlockCompat.BROWN.clayBlock,
-    ColoredBlockCompat.GRAY.clayBlock,
-    ColoredBlockCompat.BLACK.clayBlock,
-    ColoredBlockCompat.LIME.clayBlock,
-    ColoredBlockCompat.GREEN.clayBlock,
-    ColoredBlockCompat.BLUE.clayBlock,
-    ColoredBlockCompat.RED.clayBlock,
-    ColoredBlockCompat.LIGHT_GRAY.clayBlock,
-    Blocks.CLAY,
-    Blocks.STONE_BRICKS,
-    Blocks.MOSSY_STONE_BRICKS,
-    Blocks.CRACKED_STONE_BRICKS,
-    Blocks.CHISELED_STONE_BRICKS,
-    Blocks.STONE,
-    Blocks.DIORITE,
-    Blocks.GRANITE,
-    Blocks.ANDESITE,
-)
-
-private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.INFESTED_STONE,
-    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-)
-
-private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.STONE,
-    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-)
-
-private fun isRedSand(state: BlockState): Boolean =
-    state.block == Blocks.RED_SAND
-
-private fun isLowTierUmber(state: BlockState): Boolean =
-    state.block == Blocks.TERRACOTTA
-
-private fun isMidTierUmber(state: BlockState): Boolean =
-    state.block == ColoredBlockCompat.BROWN.clayBlock
-
-private fun isHighTierUmber(state: BlockState): Boolean =
-    state.block == Blocks.SMOOTH_RED_SANDSTONE
-
-private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
-    state.block == Blocks.INFESTED_COBBLESTONE
-
-private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-    Blocks.COBBLESTONE_SLAB,
-    Blocks.COBBLESTONE,
-    Blocks.COBBLESTONE_STAIRS,
-)
-
-private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
-    is StainedGlassBlock -> (block as StainedGlassBlock).color == color
-    is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
-    else -> false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -146,85 +146,88 @@ enum class OreBlock(
         fun getByStateOrNull(state: BlockState): OreBlock? = currentAreaOreBlocks.find { it.checkBlock(state) }
 
         fun getByNameOrNull(string: String) = entries.firstOrNull { it.name == string }
-
-        private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-            ColoredBlockCompat.GRAY.woolBlock,
-            ColoredBlockCompat.CYAN.clayBlock,
-        )
-
-        private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
-            Blocks.PRISMARINE,
-            Blocks.PRISMARINE_BRICKS,
-            Blocks.DARK_PRISMARINE,
-        )
-
-        private fun isHighTierMithril(state: BlockState): Boolean =
-            state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
-
-        fun isTitanium(state: BlockState): Boolean =
-            state.block == Blocks.POLISHED_DIORITE
-
-        private fun isStone(state: BlockState): Boolean =
-            state.block == Blocks.STONE
-
-        private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
-            ColoredBlockCompat.GRAY.woolBlock,
-            ColoredBlockCompat.GREEN.woolBlock,
-            ColoredBlockCompat.CYAN.clayBlock,
-            ColoredBlockCompat.BROWN.clayBlock,
-            ColoredBlockCompat.GRAY.clayBlock,
-            ColoredBlockCompat.BLACK.clayBlock,
-            ColoredBlockCompat.LIME.clayBlock,
-            ColoredBlockCompat.GREEN.clayBlock,
-            ColoredBlockCompat.BLUE.clayBlock,
-            ColoredBlockCompat.RED.clayBlock,
-            ColoredBlockCompat.LIGHT_GRAY.clayBlock,
-            Blocks.CLAY,
-            Blocks.STONE_BRICKS,
-            Blocks.MOSSY_STONE_BRICKS,
-            Blocks.CRACKED_STONE_BRICKS,
-            Blocks.CHISELED_STONE_BRICKS,
-            Blocks.STONE,
-            Blocks.DIORITE,
-            Blocks.GRANITE,
-            Blocks.ANDESITE,
-        )
-
-        private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
-            Blocks.INFESTED_STONE,
-            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-        )
-
-        private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-            Blocks.STONE,
-            ColoredBlockCompat.LIGHT_GRAY.woolBlock,
-        )
-
-        private fun isRedSand(state: BlockState): Boolean =
-            state.block == Blocks.RED_SAND
-
-        private fun isLowTierUmber(state: BlockState): Boolean =
-            state.block == Blocks.TERRACOTTA
-
-        private fun isMidTierUmber(state: BlockState): Boolean =
-            state.block == ColoredBlockCompat.BROWN.clayBlock
-
-        private fun isHighTierUmber(state: BlockState): Boolean =
-            state.block == Blocks.SMOOTH_RED_SANDSTONE
-
-        private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
-            state.block == Blocks.INFESTED_COBBLESTONE
-
-        private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
-            Blocks.COBBLESTONE_SLAB,
-            Blocks.COBBLESTONE,
-            Blocks.COBBLESTONE_STAIRS,
-        )
-
-        private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
-            is StainedGlassBlock -> (block as StainedGlassBlock).color == color
-            is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
-            else -> false
-        }
     }
+}
+
+// The block checks below must stay top level. The entries reference them while the enum is being initialised, which is
+// before the companion object instance exists, so a reference to a companion member would capture a null receiver.
+
+private fun isLowTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+    ColoredBlockCompat.GRAY.woolBlock,
+    ColoredBlockCompat.CYAN.clayBlock,
+)
+
+private fun isMidTierMithril(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.PRISMARINE,
+    Blocks.PRISMARINE_BRICKS,
+    Blocks.DARK_PRISMARINE,
+)
+
+private fun isHighTierMithril(state: BlockState): Boolean =
+    state.block == ColoredBlockCompat.LIGHT_BLUE.woolBlock
+
+fun isTitanium(state: BlockState): Boolean =
+    state.block == Blocks.POLISHED_DIORITE
+
+private fun isStone(state: BlockState): Boolean =
+    state.block == Blocks.STONE
+
+private fun isHardStoneHollows(state: BlockState): Boolean = state.block.equalsOneOf(
+    ColoredBlockCompat.GRAY.woolBlock,
+    ColoredBlockCompat.GREEN.woolBlock,
+    ColoredBlockCompat.CYAN.clayBlock,
+    ColoredBlockCompat.BROWN.clayBlock,
+    ColoredBlockCompat.GRAY.clayBlock,
+    ColoredBlockCompat.BLACK.clayBlock,
+    ColoredBlockCompat.LIME.clayBlock,
+    ColoredBlockCompat.GREEN.clayBlock,
+    ColoredBlockCompat.BLUE.clayBlock,
+    ColoredBlockCompat.RED.clayBlock,
+    ColoredBlockCompat.LIGHT_GRAY.clayBlock,
+    Blocks.CLAY,
+    Blocks.STONE_BRICKS,
+    Blocks.MOSSY_STONE_BRICKS,
+    Blocks.CRACKED_STONE_BRICKS,
+    Blocks.CHISELED_STONE_BRICKS,
+    Blocks.STONE,
+    Blocks.DIORITE,
+    Blocks.GRANITE,
+    Blocks.ANDESITE,
+)
+
+private fun isHardstoneTunnels(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.INFESTED_STONE,
+    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+)
+
+private fun isHardstoneMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.STONE,
+    ColoredBlockCompat.LIGHT_GRAY.woolBlock,
+)
+
+private fun isRedSand(state: BlockState): Boolean =
+    state.block == Blocks.RED_SAND
+
+private fun isLowTierUmber(state: BlockState): Boolean =
+    state.block == Blocks.TERRACOTTA
+
+private fun isMidTierUmber(state: BlockState): Boolean =
+    state.block == ColoredBlockCompat.BROWN.clayBlock
+
+private fun isHighTierUmber(state: BlockState): Boolean =
+    state.block == Blocks.SMOOTH_RED_SANDSTONE
+
+private fun isLowTierTungstenTunnels(state: BlockState): Boolean =
+    state.block == Blocks.INFESTED_COBBLESTONE
+
+private fun isLowTierTungstenMineshaft(state: BlockState): Boolean = state.block.equalsOneOf(
+    Blocks.COBBLESTONE_SLAB,
+    Blocks.COBBLESTONE,
+    Blocks.COBBLESTONE_STAIRS,
+)
+
+private fun BlockState.isGemstoneWithColor(color: DyeColor): Boolean = when (block) {
+    is StainedGlassBlock -> (block as StainedGlassBlock).color == color
+    is StainedGlassPaneBlock -> (block as StainedGlassPaneBlock).color == color
+    else -> false
 }


### PR DESCRIPTION
## What
Fixed some mining-related features breaking, and on 1.21.11 even crashing the game, caused by a cleanup I was told to do in 31fdde9ef7156048d5a42c2179356924fe8e94ab. I blame @AverageUser125.

The enum entries must call these checks through a lambda, never through a method reference.
A method reference to a companion member captures the companion instance when the reference is created,
which happens while the enum entries are being initialized, before the companion instance exists.
A lambda resolves the companion at call time instead, which is safe.

## Changelog Fixes
+ Fixed ore block detection being broken, which also crashed the game on 1.21.11. - Luna
    * Affected Mithril, Titanium, Hard Stone, Red Sand, Umber, and Tungsten detection.