### PR TITLE
Fix: Error when using /shnav with a search term

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
@@ -3,13 +3,11 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.DelayedRun.runNextTick
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainTo
 import net.minecraft.client.Minecraft
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.time.Duration
 
-// TODO add names for runs
 @SkyHanniModule
 object DelayedRun {
 
@@ -20,17 +18,22 @@ object DelayedRun {
      * Runs [runnable] at the end of the next game tick after [duration] has passed,
      * always on the main thread.
      */
-    fun runDelayed(duration: Duration, runnable: Runnable): SimpleTimeMark {
+    fun runDelayed(duration: Duration, label: String?, runnable: Runnable): SimpleTimeMark {
         val time = SimpleTimeMark.now() + duration
-        futureTasks.add((runnable::run).withErrorHandling("DelayedRun.runDelayed") to time)
+        futureTasks.add((runnable::run).withErrorHandling("DelayedRun.runDelayed", label) to time)
         return time
     }
 
-    fun <T> runDelayedReturning(duration: Duration, block: () -> T): Pair<SimpleTimeMark, () -> T> {
+    fun runDelayed(duration: Duration, runnable: Runnable): SimpleTimeMark = runDelayed(duration, null, runnable)
+
+    fun <T> runDelayedReturning(duration: Duration, label: String?, block: () -> T): Pair<SimpleTimeMark, () -> T> {
         val time = SimpleTimeMark.now() + duration
-        futureTasks.add(block.withErrorHandling("DelayedRun.runDelayedReturning") to time)
+        futureTasks.add(block.withErrorHandling("DelayedRun.runDelayedReturning", label) to time)
         return time to block
     }
+
+    fun <T> runDelayedReturning(duration: Duration, block: () -> T): Pair<SimpleTimeMark, () -> T> =
+        runDelayedReturning(duration, null, block)
 
     // TODO maybe rename to runOnNextMinecraftTick
     /**
@@ -38,8 +41,11 @@ object DelayedRun {
      * at the start of the next game tick. The exact point relative to SkyHanni's own event
      * handlers is not guaranteed.
      */
+    fun runNextTick(label: String?, runnable: Runnable) =
+        Minecraft.getInstance().schedule(runnable.withErrorHandling("DelayedRun.runNextTick", label))
+
     @JvmStatic
-    fun runNextTick(runnable: Runnable) = Minecraft.getInstance().schedule(runnable.withErrorHandling("DelayedRun.runNextTick"))
+    fun runNextTick(runnable: Runnable) = runNextTick(null, runnable)
 
     // TODO maybe rename to runAfterCurrentTickEvents
     /**
@@ -49,27 +55,33 @@ object DelayedRun {
      * Use this when the task reads state that other handlers (e.g. chat handlers) may still
      * modify during the current tick.
      */
+    fun runNextTickEnd(label: String?, runnable: Runnable) =
+        futureTasks.add((runnable::run).withErrorHandling("DelayedRun.runNextTickEnd", label) to SimpleTimeMark.farPast())
+
     @JvmStatic
-    fun runNextTickEnd(runnable: Runnable) =
-        futureTasks.add((runnable::run).withErrorHandling("DelayedRun.runNextTickEnd") to SimpleTimeMark.farPast())
+    fun runNextTickEnd(runnable: Runnable) = runNextTickEnd(null, runnable)
 
     /**
      * Runs [runnable] now if we are on the main thread, otherwise schedules it for the start of the
      * next game tick, same as [runNextTick].
      */
-    fun runOrNextTick(runnable: Runnable) = Minecraft.getInstance().execute(runnable.withErrorHandling("DelayedRun.runOrNextTick"))
+    fun runOrNextTick(label: String?, runnable: Runnable) =
+        Minecraft.getInstance().execute(runnable.withErrorHandling("DelayedRun.runOrNextTick", label))
+
+    fun runOrNextTick(runnable: Runnable) = runOrNextTick(null, runnable)
 
     /**
      * Runs [block], reporting a crash to the [ErrorManager] instead of letting it escape.
-     * [source] names the scheduling method the task came from.
+     * [source] names the scheduling method the task came from, [label] the caller's own description of the task.
      */
-    private fun runWithErrorHandling(source: String, block: () -> Any?) {
+    private fun runWithErrorHandling(source: String, label: String?, block: () -> Any?) {
         try {
             block()
         } catch (e: Throwable) {
             ErrorManager.logErrorWithData(
                 e,
                 "Delayed task crashed while executing: ${e.message}",
+                "label" to (label ?: "<none>"),
                 "source" to source,
             )
         }
@@ -77,16 +89,17 @@ object DelayedRun {
 
     /**
      * Wraps [this] so that a crash is reported to the [ErrorManager] instead of taking down the game.
+     * Minecraft's own executor has no error handling, so anything scheduled on it needs this.
      */
-    private fun Runnable.withErrorHandling(source: String) = Runnable {
-        runWithErrorHandling(source) { run() }
+    private fun Runnable.withErrorHandling(source: String, label: String?) = Runnable {
+        runWithErrorHandling(source, label) { run() }
     }
 
     /**
-     * Wraps [this] the same way [Runnable.withErrorHandling] does, for tasks stored as a function type.
+     * Wraps [this] the same way the [Runnable] variant does, for tasks stored as a function type.
      */
-    internal fun (() -> Any?).withErrorHandling(source: String): () -> Unit = {
-        runWithErrorHandling(source, this)
+    internal fun (() -> Any?).withErrorHandling(source: String, label: String?): () -> Unit = {
+        runWithErrorHandling(source, label, this)
     }
 
     @HandleEvent(priority = HandleEvent.LOWEST)

--- a/src/main/java/at/hannibal2/skyhanni/utils/DelayedServerRun.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DelayedServerRun.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun.withErrorHandling
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainTo
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.time.Duration
+import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 
 /**
  * Helper class for delaying execution until a specific server time mark.
@@ -22,20 +23,20 @@ object DelayedServerRun {
     private val tasks = mutableListOf<Pair<() -> Any, ServerTimeMark>>()
     private val futureTasks = ConcurrentLinkedQueue<Pair<() -> Any, ServerTimeMark>>()
 
-    fun runDelayed(duration: Duration, run: () -> Unit): ServerTimeMark {
+    fun runDelayed(duration: Duration, label: String? = null, run: () -> Unit): ServerTimeMark {
         val time = ServerTimeMark.now() + duration
-        futureTasks.add(run.withErrorHandling("DelayedServerRun.runDelayed") to time)
+        futureTasks.add(run.withErrorHandling("DelayedServerRun.runDelayed", label) to time)
         return time
     }
 
-    fun <T> runDelayedReturning(duration: Duration, run: () -> T): Pair<ServerTimeMark, () -> T> {
+    fun <T> runDelayedReturning(duration: Duration, label: String? = null, run: () -> T): Pair<ServerTimeMark, () -> T> {
         val time = ServerTimeMark.now() + duration
-        futureTasks.add(run.withErrorHandling("DelayedServerRun.runDelayedReturning") to time)
+        futureTasks.add(run.withErrorHandling("DelayedServerRun.runDelayedReturning", label) to time)
         return time to run
     }
 
-    fun runNextTick(run: () -> Unit) =
-        futureTasks.add(run.withErrorHandling("DelayedServerRun.runNextTick") to ServerTimeMark.farPast())
+    fun runNextTick(label: String? = null, run: () -> Unit) =
+        futureTasks.add(run.withErrorHandling("DelayedServerRun.runNextTick", label) to ServerTimeMark.farPast())
 
     @HandleEvent(priority = HandleEvent.LOWEST)
     private fun onServerTick() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/DelayedServerRun.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DelayedServerRun.kt
@@ -1,12 +1,12 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun.withErrorHandling
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainTo
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.time.Duration
-import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 
 /**
  * Helper class for delaying execution until a specific server time mark.

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.utils.chat
 
 import at.hannibal2.skyhanni.utils.ColorUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -135,7 +136,7 @@ object TextHelper {
         maxPerPage: Int = 15,
         dividerColor: ChatFormatting = ChatFormatting.BLUE,
         formatter: (T) -> Component,
-    ) {
+    ): Unit = DelayedRun.runOrNextTick("paginated list: $title") {
         val text = mutableListOf<Component>()
 
         val totalPages = (list.size + maxPerPage - 1) / maxPerPage


### PR DESCRIPTION
## Dependencies
- #6297

## What
`/shnav <search>` runs its lookup in a coroutine, so `TextHelper.displayPaginatedList` ended up measuring text width off the main thread. `Font.width` bakes a glyph on first use, and that bake uploads a texture, which throws when it does not happen on the render thread.

`displayPaginatedList` now runs through `DelayedRun.runOrNextTick`, so every caller reaches the font and the chat from the main thread. Callers already on the main thread are unaffected, the task runs immediately.

## Changelog Fixes
+ Fixed an error when using /shnav with a search term. - hannibal2