### PR TITLE
Feature: Add Stonks Auction countdown and bid reminders

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
@@ -83,8 +83,7 @@ class EventConfig {
     @Expose
     val yearOfTheWitch: YearOfTheWitchConfig = YearOfTheWitchConfig()
 
-    @ConfigOption(name = "Stonks Auction", desc = "")
-    @Accordion
+    @Category(name = "Stonks Auction", desc = "Features for the Stonks Auction while the Stock Exchange perk is active.")
     @Expose
     val stonksAuction: StonksAuctionConfig = StonksAuctionConfig()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
@@ -83,6 +83,11 @@ class EventConfig {
     @Expose
     val yearOfTheWitch: YearOfTheWitchConfig = YearOfTheWitchConfig()
 
+    @ConfigOption(name = "Stonks Auction", desc = "")
+    @Accordion
+    @Expose
+    val stonksAuction: StonksAuctionConfig = StonksAuctionConfig()
+
     @Category(name = "Lobby Waypoints", desc = "Lobby Event Waypoint settings")
     @Expose
     val lobbyWaypoints: LobbyWaypointsConfig = LobbyWaypointsConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/StonksAuctionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/StonksAuctionConfig.kt
@@ -31,5 +31,5 @@ class StonksAuctionConfig {
 
     @Expose
     @ConfigLink(owner = StonksAuctionConfig::class, field = "countdown")
-    val countdownPosition: Position = Position(10, 10)
+    val countdownPosition: Position = Position(-10, 10)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/StonksAuctionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/StonksAuctionConfig.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class StonksAuctionConfig {
+    @Expose
+    @ConfigOption(name = "Countdown", desc = "Display a countdown until the current Stonks Auction round ends.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var countdown: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "One Minute Warning",
+        desc = "Warn you when the Stonks Auction round has less than a minute left, especially if you haven't bid yet.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var oneMinuteWarning: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "New Round Alert", desc = "Send a chat message when a new Stonks Auction round starts.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var newRoundAlert: Boolean = true
+
+    @Expose
+    @ConfigLink(owner = StonksAuctionConfig::class, field = "countdown")
+    val countdownPosition: Position = Position(10, 10)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -432,6 +432,9 @@ class ProfileSpecificStorage(
     @Expose
     var stonksAuctionLastBidRoundEnd: SimpleTimeMark = farPast()
 
+    @Expose
+    var stonksAuctionBidAmount: Long = 0L
+
     // - fishing
     @Expose
     var fishing: FishingStorage = FishingStorage()

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -425,6 +425,13 @@ class ProfileSpecificStorage(
     @Expose
     var communityShopProfileUpgrade: CommunityShopUpgrade? = null
 
+    // - stock exchange
+    @Expose
+    var stonksAuctionRoundEnd: SimpleTimeMark = farPast()
+
+    @Expose
+    var stonksAuctionLastBidRoundEnd: SimpleTimeMark = farPast()
+
     // - fishing
     @Expose
     var fishing: FishingStorage = FishingStorage()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/stockexchange/StonksAuctionTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/stockexchange/StonksAuctionTimer.kt
@@ -9,12 +9,19 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.timerColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import java.awt.Color
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
@@ -23,44 +30,85 @@ object StonksAuctionTimer {
     private val config get() = SkyHanniMod.feature.event.stonksAuction
     private val storage get() = ProfileStorageData.profileSpecific
 
+    // real rounds are at least 1h40m apart; anything smaller is just re-parse jitter from re-reading the same round's tooltip
+    private val ROUND_CHANGE_TOLERANCE = 5.minutes
+
     private var lastSeenRoundEnd = SimpleTimeMark.farPast()
     private var lastWarnedRoundEnd = SimpleTimeMark.farPast()
+    private var display: Renderable? = null
 
-    private val roundEnd get() = storage?.stonksAuctionRoundEnd ?: SimpleTimeMark.farPast()
+    // rounds are anchored to SkyBlock calendar month boundaries (1 SkyBlock month = 10h20m = the observed round length),
+    // used as an estimate until the exact value has been read from the in-game tooltip at least once this round
+    private val roundEnd: SimpleTimeMark
+        get() {
+            val exact = storage?.stonksAuctionRoundEnd
+            if (exact != null && exact.isInFuture()) return exact
+            return calendarEstimatedRoundEnd()
+        }
+
     private val hasBidThisRound get() = storage?.stonksAuctionLastBidRoundEnd == roundEnd
+    private val bidAmount get() = storage?.stonksAuctionBidAmount ?: 0L
+
+    private fun isSameRound(a: SimpleTimeMark, b: SimpleTimeMark) = a.absoluteDifference(b) <= ROUND_CHANGE_TOLERANCE
+
+    private fun calendarEstimatedRoundEnd(): SimpleTimeMark {
+        val now = SkyBlockTime.now()
+        val monthStart = SkyBlockTime(year = now.year, month = now.month)
+        return (monthStart + SkyBlockTime.SKYBLOCK_MONTH_MILLIS.milliseconds).toTimeMark()
+    }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.countdown) return
-        if (!Perk.STOCK_EXCHANGE.isActive) return
-        val roundEnd = roundEnd
-        if (!roundEnd.isInFuture()) return
-
-        val bidStatus = if (hasBidThisRound) "§a✔ Bid placed" else "§c✘ Not bid!"
-        val display = Renderable.text("§6Stonks Auction §7ends in §e${roundEnd.timeUntil().format(maxUnits = 2)} $bidStatus")
-        config.countdownPosition.renderRenderable(display, posLabel = "Stonks Auction Timer")
+        display?.let { config.countdownPosition.renderRenderable(it, posLabel = "Stonks Auction Timer") }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!Perk.STOCK_EXCHANGE.isActive) return
+        if (!Perk.STOCK_EXCHANGE.isActive) {
+            display = null
+            return
+        }
         val roundEnd = roundEnd
-        if (!roundEnd.isInFuture()) return
-
-        if (roundEnd != lastSeenRoundEnd) {
-            val isFirstObservation = lastSeenRoundEnd.isFarPast()
-            lastSeenRoundEnd = roundEnd
-            lastWarnedRoundEnd = SimpleTimeMark.farPast()
-            if (config.newRoundAlert && !isFirstObservation) {
-                ChatUtils.chat("§6A new Stonks Auction round has started! §7Ends in §e${roundEnd.timeUntil().format(maxUnits = 2)}")
-            }
+        if (!roundEnd.isInFuture()) {
+            display = null
+            return
         }
 
-        if (config.oneMinuteWarning && roundEnd.timeUntil() <= 1.minutes && lastWarnedRoundEnd != roundEnd) {
-            lastWarnedRoundEnd = roundEnd
-            val bidWarning = if (hasBidThisRound) "" else " §c§lYou haven't bid yet!"
-            SoundUtils.repeatSound(100, 2, SoundUtils.createSound("block.note_block.pling", 0.5f))
-            TitleManager.sendTitle("§6Stonks Auction ending soon!$bidWarning")
+        updateNewRoundState(roundEnd)
+        updateOneMinuteWarning(roundEnd)
+
+        display = if (config.countdown) buildDisplay(roundEnd) else null
+    }
+
+    private fun buildDisplay(roundEnd: SimpleTimeMark): Renderable {
+        val timeUntil = roundEnd.timeUntil()
+        val color = timeUntil.timerColor("§e")
+        val bidStatus = if (hasBidThisRound) "§a✔ Bid: §e${bidAmount.addSeparators()} Coins" else "§c✘ Not bid!"
+        val countdownLine = Renderable.text("§6Stonks Auction §7ends in $color${timeUntil.format(maxUnits = 2)}")
+        val bidLine = Renderable.text(bidStatus)
+        val textRenderable = Renderable.vertical(countdownLine, bidLine, horizontalAlign = HorizontalAlignment.CENTER)
+        return Renderable.drawInsideRoundedRect(textRenderable, color = Color(255, 255, 255, 100), radius = 5)
+    }
+
+    private fun updateNewRoundState(roundEnd: SimpleTimeMark) {
+        if (isSameRound(roundEnd, lastSeenRoundEnd)) return
+        val isFirstObservation = lastSeenRoundEnd.isFarPast()
+        lastSeenRoundEnd = roundEnd
+        lastWarnedRoundEnd = SimpleTimeMark.farPast()
+        if (config.newRoundAlert && !isFirstObservation) {
+            ChatUtils.chat("§6A new Stonks Auction round has started! §7Ends in §e${roundEnd.timeUntil().format(maxUnits = 2)}")
         }
+    }
+
+    private fun updateOneMinuteWarning(roundEnd: SimpleTimeMark) {
+        if (!config.oneMinuteWarning) return
+        if (roundEnd.timeUntil() > 1.minutes) return
+        if (isSameRound(roundEnd, lastWarnedRoundEnd)) return
+
+        lastWarnedRoundEnd = roundEnd
+        val bidWarning = if (hasBidThisRound) "" else " §c§lYou haven't bid yet!"
+        SoundUtils.repeatSound(100, 2, SoundUtils.createSound("block.note_block.pling", 0.5f))
+        TitleManager.sendTitle("§6Stonks Auction ending soon!$bidWarning")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/stockexchange/StonksAuctionTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/stockexchange/StonksAuctionTimer.kt
@@ -1,0 +1,66 @@
+package at.hannibal2.skyhanni.features.event.stockexchange
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.Perk
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import kotlin.time.Duration.Companion.minutes
+
+@SkyHanniModule
+object StonksAuctionTimer {
+
+    private val config get() = SkyHanniMod.feature.event.stonksAuction
+    private val storage get() = ProfileStorageData.profileSpecific
+
+    private var lastSeenRoundEnd = SimpleTimeMark.farPast()
+    private var lastWarnedRoundEnd = SimpleTimeMark.farPast()
+
+    private val roundEnd get() = storage?.stonksAuctionRoundEnd ?: SimpleTimeMark.farPast()
+    private val hasBidThisRound get() = storage?.stonksAuctionLastBidRoundEnd == roundEnd
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!config.countdown) return
+        if (!Perk.STOCK_EXCHANGE.isActive) return
+        val roundEnd = roundEnd
+        if (!roundEnd.isInFuture()) return
+
+        val bidStatus = if (hasBidThisRound) "§a✔ Bid placed" else "§c✘ Not bid!"
+        val display = Renderable.text("§6Stonks Auction §7ends in §e${roundEnd.timeUntil().format(maxUnits = 2)} $bidStatus")
+        config.countdownPosition.renderRenderable(display, posLabel = "Stonks Auction Timer")
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!Perk.STOCK_EXCHANGE.isActive) return
+        val roundEnd = roundEnd
+        if (!roundEnd.isInFuture()) return
+
+        if (roundEnd != lastSeenRoundEnd) {
+            val isFirstObservation = lastSeenRoundEnd.isFarPast()
+            lastSeenRoundEnd = roundEnd
+            lastWarnedRoundEnd = SimpleTimeMark.farPast()
+            if (config.newRoundAlert && !isFirstObservation) {
+                ChatUtils.chat("§6A new Stonks Auction round has started! §7Ends in §e${roundEnd.timeUntil().format(maxUnits = 2)}")
+            }
+        }
+
+        if (config.oneMinuteWarning && roundEnd.timeUntil() <= 1.minutes && lastWarnedRoundEnd != roundEnd) {
+            lastWarnedRoundEnd = roundEnd
+            val bidWarning = if (hasBidThisRound) "" else " §c§lYou haven't bid yet!"
+            SoundUtils.repeatSound(100, 2, SoundUtils.createSound("block.note_block.pling", 0.5f))
+            TitleManager.sendTitle("§6Stonks Auction ending soon!$bidWarning")
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.transformAt
 import at.hannibal2.skyhanni.utils.compat.append
@@ -76,11 +75,9 @@ object StockOfStonkFeature {
 
     var inInventory = false
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryOpen(event: InventoryOpenEvent) {
-        if (SkyBlockUtils.inSkyBlock) {
-            inInventory = inventoryPattern.matches(event.inventoryName)
-        }
+        inInventory = inventoryPattern.matches(event.inventoryName)
     }
 
     @HandleEvent
@@ -88,9 +85,8 @@ object StockOfStonkFeature {
         inInventory = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipTextEvent) {
-        if (!SkyBlockUtils.inSkyBlock) return
         if (!inInventory) return
         if (!inventoryPattern.matches(event.itemStack.cleanName)) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -11,9 +11,11 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils.transformIf
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.transformAt
@@ -61,7 +63,7 @@ object StockOfStonkFeature {
      */
     private val currentBidPattern by patternGroup.pattern(
         "currentbid",
-        "Your current bid: (?<bid>.+)",
+        "Your current bid: (?:None|(?<amount>[\\d,]+) Coins)",
     )
 
     /**
@@ -123,20 +125,21 @@ object StockOfStonkFeature {
     private fun updateAuctionData(event: ToolTipTextEvent) {
         val storage = ProfileStorageData.profileSpecific ?: return
         var roundEnd: SimpleTimeMark? = null
-        var hasBid = false
+        var bidAmount: Long? = null
         for (line in event.toolTip) {
             auctionEndsPattern.matchMatcher(line) {
                 val duration = TimeUtils.getDurationOrNull(group("duration")) ?: return@matchMatcher
-                roundEnd = SimpleTimeMark.now() + duration
+                roundEnd = duration.fromNow()
             }
             currentBidPattern.matchMatcher(line) {
-                hasBid = group("bid") != "None"
+                bidAmount = groupOrNull("amount")?.formatLong()
             }
         }
         val newRoundEnd = roundEnd ?: return
         storage.stonksAuctionRoundEnd = newRoundEnd
-        if (hasBid) {
+        bidAmount?.let {
             storage.stonksAuctionLastBidRoundEnd = newRoundEnd
+            storage.stonksAuctionBidAmount = it
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
@@ -12,7 +13,9 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.transformAt
 import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.replace
@@ -52,11 +55,28 @@ object StockOfStonkFeature {
         " {3}Minimum Bid: (?<amount>[\\d,]+) Coins",
     )
 
+    /**
+     * REGEX-TEST: Your current bid: None
+     * REGEX-TEST: Your current bid: 2,500,500 Coins
+     */
+    private val currentBidPattern by patternGroup.pattern(
+        "currentbid",
+        "Your current bid: (?<bid>.+)",
+    )
+
+    /**
+     * REGEX-TEST: Auction ends in 4h 32m
+     */
+    private val auctionEndsPattern by patternGroup.pattern(
+        "endsin",
+        "Auction ends in (?<duration>.+)",
+    )
+
     var inInventory = false
 
     @HandleEvent
     fun onInventoryOpen(event: InventoryOpenEvent) {
-        if (isEnabled()) {
+        if (SkyBlockUtils.inSkyBlock) {
             inInventory = inventoryPattern.matches(event.inventoryName)
         }
     }
@@ -68,9 +88,13 @@ object StockOfStonkFeature {
 
     @HandleEvent
     fun onToolTip(event: ToolTipTextEvent) {
-        if (!isEnabled()) return
+        if (!SkyBlockUtils.inSkyBlock) return
         if (!inInventory) return
         if (!inventoryPattern.matches(event.itemStack.cleanName)) return
+
+        updateAuctionData(event)
+
+        if (!config.stonkOfStonkPrice) return
         var stonksReward = 0
         var index = 0
         var bestValueIndex = 0
@@ -96,5 +120,23 @@ object StockOfStonkFeature {
         event.toolTip.transformAt(bestValueIndex) { replace("§6§6", "§a") ?: this }
     }
 
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.stonkOfStonkPrice
+    private fun updateAuctionData(event: ToolTipTextEvent) {
+        val storage = ProfileStorageData.profileSpecific ?: return
+        var roundEnd: SimpleTimeMark? = null
+        var hasBid = false
+        for (line in event.toolTip) {
+            auctionEndsPattern.matchMatcher(line) {
+                val duration = TimeUtils.getDurationOrNull(group("duration")) ?: return@matchMatcher
+                roundEnd = SimpleTimeMark.now() + duration
+            }
+            currentBidPattern.matchMatcher(line) {
+                hasBid = group("bid") != "None"
+            }
+        }
+        val newRoundEnd = roundEnd ?: return
+        storage.stonksAuctionRoundEnd = newRoundEnd
+        if (hasBid) {
+            storage.stonksAuctionLastBidRoundEnd = newRoundEnd
+        }
+    }
 }


### PR DESCRIPTION
## What
Adds a countdown and bid reminders for the Stonks Auction (Diaz's Stock Exchange perk). The timer reads directly from the in-game tooltip and keeps counting down even when the auction menu is closed. Also warns you when a round is about to end and lets you know when a new one starts. Only shows when Diaz's Stock Exchange perk is active. 

<details>
<summary>Images</summary>

Config: Events -> Stonks Auction
<img width="1005" height="808" alt="image" src="https://github.com/user-attachments/assets/cd71bb90-c599-4f06-bb7d-131d9bea2982" />

Not Bid:
<img width="328" height="65" alt="Storka Fluction enda in 3h 38m" src="https://github.com/user-attachments/assets/84f0e852-0786-4c39-842c-299ec14b59f2" />

Bid with bid amount:
<img width="322" height="58" alt="Sionke duction ende in 9h 96m" src="https://github.com/user-attachments/assets/e1871968-e2fd-420b-95f2-07fd4a8b97b7" />

Auction:
<img width="573" height="476" alt="Stonks fluction" src="https://github.com/user-attachments/assets/83b47e7c-b576-436c-8b5a-2b84fb6da662" />

</details>

## Changelog New Features
+ Added a countdown timer showing how long is left in the current Stonks Auction round, along with whether you've placed a bid yet. - RemainingDelta
+ Added a warning when the auction is about to end and a chat message when a new round starts. - RemainingDelta
