### PR TITLE
Backend: Copy Bestiary bracketType

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
@@ -41,6 +41,9 @@ object TestCopyBestiaryValues {
         var mobs: Array<String> = emptyArray()
 
         @Expose
+        var bracketType: String? = null
+
+        @Expose
         var bracket: Int = 0
     }
 
@@ -92,7 +95,7 @@ object TestCopyBestiaryValues {
         for (i in 10..43) {
             val stack = inventoryItems[i] ?: continue
             bestiaryTypePattern.matchMatcher(stack.cleanName) {
-                val lvl = group("lvl").toInt()
+                val lvl = group("lvl").replace(",", "").toInt()
                 var text = group("text").lowercase().replace(" ", "_")
 
                 val master = text.endsWith("(master)")
@@ -105,6 +108,10 @@ object TestCopyBestiaryValues {
             }
         }
         obj.mobs = mobs.toTypedArray()
+
+        if (lore.any { it.contains("Critter") }) {
+            obj.bracketType = "CRITTER"
+        }
 
         val gson = GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create()
         val text = gson.toJson(obj)

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
@@ -55,7 +55,7 @@ object TestCopyBestiaryValues {
     )
 
     @HandleEvent(priority = HandleEvent.LOW)
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!DevApi.config.debug.copyBestiaryData) return
         SkyHanniDebugsAndTests.displayLine = null
 
@@ -95,7 +95,7 @@ object TestCopyBestiaryValues {
         for (i in 10..43) {
             val stack = inventoryItems[i] ?: continue
             bestiaryTypePattern.matchMatcher(stack.cleanName) {
-                val lvl = group("lvl").replace(",", "").toInt()
+                val lvl = group("lvl").formatInt()
                 var text = group("text").lowercase().replace(" ", "_")
 
                 val master = text.endsWith("(master)")
@@ -121,7 +121,7 @@ object TestCopyBestiaryValues {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "dev.copyBestiaryData", "dev.debug.copyBestiaryData")
     }
 }


### PR DESCRIPTION
- Fixes error when copying bestiary with mobs above lvl 1k
- Adds bracketType support for critters


exclude_from_changelog
