### PR TITLE
Fix: Track new shard fished message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
@@ -20,6 +20,7 @@ enum class ShardSource {
     NAGA,
     SALT,
     HUNT,
+    FISHING,
     SENT_TO_HUNTING_BOX,
     CAPTURED,
     FLOOR_DROP,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -247,6 +247,16 @@ object AttributeShardsData {
     )
 
     /**
+     * REGEX-TEST:  GOOD CATCH! You caught Water Snake Shard x3!
+     * REGEX-TEST:  GREAT CATCH! You caught Giant Water Bug Shard x3!
+     * REGEX-TEST:  GOOD CATCH! You caught a Water Snake Shard!
+     */
+    private val caughtMultipleShardsPattern by patternGroup.pattern(
+        "caught-multiple.shards",
+        "\uE025 .+ CATCH! You caught(?: [an]+)? (?<shardName>.+) Shard(?: x(?<amount>\\d+))?!"
+    )
+
+    /**
      * REGEX-TEST: LOOT SHARE You received a Glacite Walker Shard for assisting Mealoan!
      * REGEX-TEST: LOOT SHARE You received 2 Mossybit Shards for assisting FallenYeti!
      */
@@ -322,6 +332,7 @@ object AttributeShardsData {
     // the boolean is if it should post the shard gain event
     private val shardGainChatPatterns = mapOf(
         caughtShardsPattern to (true to ShardSource.HUNT),
+        caughtMultipleShardsPattern to (true to ShardSource.FISHING),
         lootShareShardPattern to (true to ShardSource.HUNT),
         charmedShardPattern to (true to null),
         sentToHuntingBoxPattern to (false to ShardSource.SENT_TO_HUNTING_BOX),


### PR DESCRIPTION
## What
Another new message, didnt seem right to make a fucked pattern that combined this and the old one that is still used a bit

## Changelog Fixes
+ Fixed Fishing Profit Trackers not detecting shards from fishing. - CalMWolfs
