### PR TITLE
Fix: Lottery Perk Display Colors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -18,22 +18,22 @@ object HotfApi {
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         SWEEP(
-            displayDescription = "§a+10§r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
+            displayDescription = "§2+10${SkyblockStat.SWEEP.hypixelIcon} Sweep",
             chatFallback = "Gain \\+10${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
             itemFallback = "Gain \\+10${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
-            displayDescription = "§a+50§r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
+            displayDescription = "§6+50${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
             chatFallback = "Gain \\+50${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
             itemFallback = "Gain \\+50${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
-            displayDescription = "§a+50§r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
+            displayDescription = "§6+50${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
             chatFallback = "Gain \\+50${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
             itemFallback = "Gain \\+50${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         HELIX_FORTUNE(
-            displayDescription = "§a+50§r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
+            displayDescription = "§6+50${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
             chatFallback = "Gain \\+50${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
             itemFallback = "Gain \\+50${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
         ),


### PR DESCRIPTION
## What
Okay, now the entire line is the same color.
Idk how I missed this.
But comparing to the skymall display made me notice it.

## Changelog Fixes
+ Fixed Lottery Display colors not being uniform. - Avrg