### PR TITLE
Improvement: Queen Bee Notification should not depend on Honey Hive Reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/HoneyhiveReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/HoneyhiveReminder.kt
@@ -56,19 +56,18 @@ object HoneyhiveReminder {
 
     @HandleEvent(onlyOnIsland = IslandType.TORRHUS_CANYON)
     private fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!config.enabled) return
+        val message = event.cleanMessage
 
-        if (!currentlyNavigating && hiveLootedPattern.matches(event.cleanMessage)) {
-            val location = LocationUtils.playerLocation()
+        when {
+            config.enabled && !currentlyNavigating && hiveLootedPattern.matches(message) -> {
+                val location = LocationUtils.playerLocation()
+                startHiveNavigation("You looted a honeyhive, want to collect the rest?", location)
+            }
 
-            startHiveNavigation("You looted a honeyhive, want to collect the rest?", location)
-
-            return
+            config.queenBeeNotification && queenBeePattern.matches(message) -> {
+                TitleManager.sendTitle("§6Honeyhive Instantly Refilled!")
+            }
         }
-
-        if (!config.queenBeeNotification) return
-        if (!queenBeePattern.matches(event.cleanMessage)) return
-        TitleManager.sendTitle("§6Honeyhive Instantly Refilled!")
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
I am unsure if this is an improvment or a bug fix.
But made the "Queen Bee Shard Proc" notification work even if the "main" toggle is disabled.

## Changelog Improvements
+ Made Queen Bee Notification work without Honey Hive Reminder. - Avrg