### PR TITLE
Feature: Tooltip Price Info

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -172,6 +172,11 @@ class MiscConfig {
     val boopParty: BoopPartyConfig = BoopPartyConfig()
 
     @Expose
+    @ConfigOption(name = "Tooltip Price Info", desc = "")
+    @Accordion
+    val tooltipPriceInfo: TooltipPriceInfoConfig = TooltipPriceInfoConfig()
+
+    @Expose
     @ConfigOption(name = "Reset Search on Close", desc = "Reset the search in GUIs after closing the inventory.")
     @ConfigEditorBoolean
     var resetSearchGuiOnClose: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TooltipPriceInfoConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TooltipPriceInfoConfig.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.config.features.misc
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class TooltipPriceInfoConfig {
+
+    @Expose
+    @ConfigOption(name = "Tooltip Price Info", desc = "")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var showPriceInLore: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Price Info", desc = "Select what price information you would like to see")
+    @ConfigEditorDraggableList
+    var priceTypes: MutableList<PriceTypes> = mutableListOf(
+        PriceTypes.LBIN,
+        PriceTypes.INSTA_BUY,
+        PriceTypes.INSTA_SELL,
+        PriceTypes.NPC,
+        PriceTypes.CRAFT_COST
+    )
+
+    enum class PriceTypes(val displayName: String) {
+        LBIN("Lowest BIN"),
+        //AVG_LBIN_1("Average Lowest BIN (1 day)"),
+        //AVG_LBIN_3("Average Lowest BIN (3 days)"),
+        //AVG_LBIN_7("Average Lowest BIN (7 days)"),
+        INSTA_BUY("Insta Buy"),
+        INSTA_SELL("Insta Sell"),
+        NPC("NPC Sell Price"),
+        CRAFT_COST("Craft Cost");
+
+        override fun toString() = displayName
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TooltipPriceInfo.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TooltipPriceInfo.kt
@@ -1,0 +1,81 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.misc.TooltipPriceInfoConfig.PriceTypes
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getLowestBinOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getRawCraftCostOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
+import net.minecraft.client.Minecraft
+import net.minecraft.network.chat.Component
+import net.minecraft.world.item.ItemStack
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+
+@SkyHanniModule
+object TooltipPriceInfo {
+
+    private val config get() = SkyHanniMod.feature.misc.tooltipPriceInfo
+
+    private val format = DecimalFormat("#,##0.#", DecimalFormatSymbols(Locale.US))
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onTooltip(event: ToolTipTextEvent) {
+        if (!config.showPriceInLore || config.priceTypes.isEmpty()) return
+
+        val isShiftDown = Minecraft.getInstance().hasShiftDown()
+        val shiftMultiplier = getShiftMultiplier(event.itemStack)
+
+        val internalName = event.itemStack.getInternalName()
+        val multiplier = if (isShiftDown) shiftMultiplier else 1
+        val priceLines = getPriceLines(internalName, multiplier)
+
+        if (priceLines.isNotEmpty()) {
+            if (!isShiftDown && shiftMultiplier > 1) priceLines.add(Component.literal("§8[SHIFT show x$shiftMultiplier]"))
+            event.toolTip.add(Component.literal(""))
+            event.toolTip.addAll(priceLines)
+        }
+    }
+
+    private fun getShiftMultiplier(itemStack: ItemStack): Int {
+        if (itemStack.getItemUuid() != null) return 1
+        val shiftMultiplier = if (itemStack.count > 1) itemStack.count else itemStack.maxStackSize
+        return shiftMultiplier
+    }
+
+    private fun getPriceLines(internalName: NeuInternalName, multiplier: Int): MutableList<Component> {
+        val lines = mutableListOf<Component>()
+        for (priceType in config.priceTypes) {
+            when (priceType) {
+                PriceTypes.LBIN -> internalName.getLowestBinOrNull()?.let {
+                    val text = "§eLowest BIN: §6${format.format(it * multiplier)}"
+                    lines.add(Component.literal(text))
+                }
+                PriceTypes.INSTA_BUY -> internalName.getBazaarData()?.let {
+                    val text = "§eInsta Buy: §6${format.format(it.instantBuyPrice * multiplier)}"
+                    lines.add(Component.literal(text))
+                }
+                PriceTypes.INSTA_SELL -> internalName.getBazaarData()?.let {
+                    val text = "§eInsta Sell: §6${format.format(it.instantSellPrice * multiplier)}"
+                    lines.add(Component.literal(text))
+                }
+                PriceTypes.NPC -> internalName.getNpcPriceOrNull()?.let {
+                    val text = "§eNPC Price: §6${format.format(it * multiplier)}"
+                    lines.add(Component.literal(text))
+                }
+                PriceTypes.CRAFT_COST -> internalName.getRawCraftCostOrNull()?.let {
+                    val text = "§eCraft Cost: §6${format.format(it * multiplier)}"
+                    lines.add(Component.literal(text))
+                }
+            }
+        }
+        return lines
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -76,7 +76,7 @@ object ItemPriceUtils {
 
     fun NeuInternalName.isAuctionHouseItem(): Boolean = getLowestBinOrNull() != null
 
-    private fun NeuInternalName.getLowestBinOrNull(): Double? = when {
+    fun NeuInternalName.getLowestBinOrNull(): Double? = when {
         else -> getShLowestBin(this)
     }.takeIf { it != -1L }?.toDouble()
 


### PR DESCRIPTION
## What
Adds various price information to the bottom of an item's tooltip (like NEU).

Currently this feature shows:
- Lowest BIN
- Insta Buy
- Insta Sell
- NPC Price
- Raw Craft Cost

## Changelog New Features
+ Added Tooltip Price Info feature. - OnlYKai
    * Shows lowest bin, insta buy/sell price, npc price and raw craft cost in tooltip.