### PR TITLE
Fix: Use repo names for shards instead of attribute IDs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -185,8 +185,6 @@ object EstimatedItemValueCalculator {
         return totalPrice to basePrice
     }
 
-    private fun String.fixMending() = if (this == "MENDING") "VITALITY" else this
-
     private fun addReforgeStone(stack: SafeItemStack, list: MutableList<String>): Double {
         val rawReforgeName = stack.getReforgeModifier() ?: return 0.0
 
@@ -945,10 +943,4 @@ object EstimatedItemValueCalculator {
 
     private fun NeuInternalName.getPrice(): Double = getPriceOrNull() ?: 0.0
     private fun NeuInternalName.getPriceOrNull(): Double? = getPriceOrNull(config.priceSource.get())
-
-    // TODO create attribute class and use this instead of pair, sync with getAttributeFromShard()
-    fun Pair<String, Int>.getAttributeName(): String {
-        val name = first.fixMending().allLettersFirstUppercase()
-        return "§b$name $second Shard"
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
-import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator.getAttributeName
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CachedItemData.Companion.cachedData
@@ -34,7 +33,6 @@ import at.hannibal2.skyhanni.utils.PrimitiveIngredient.Companion.toPrimitiveItem
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
@@ -667,27 +665,11 @@ object ItemUtils {
 
     /** Use when showing the item name to the user (in guis, chat message, etc.), not for comparing. */
     val SafeItemStack.repoItemName: String
-        get() {
-            getAttributeFromShard()?.let {
-                return it.getAttributeName()
-            }
-            return getInternalNameOrNull()?.repoItemName ?: "<null>"
-        }
+        get() = getInternalNameOrNull()?.repoItemName ?: "<null>"
 
     /** Use when showing the item name to the user (in guis, chat message, etc.), not for comparing. */
     val SafeItemStack.repoItemNameCompact: String
-        get() {
-            getAttributeFromShard()?.let {
-                return it.getAttributeName()
-            }
-            return getInternalNameOrNull()?.repoItemNameCompact ?: "<null>"
-        }
-
-    fun SafeItemStack.getAttributeFromShard(): Pair<String, Int>? {
-        if (!(getInternalName().asString().startsWith("ATTRIBUTE_SHARD"))) return null
-        val attributes = getAttributes() ?: return null
-        return attributes.firstOrNull()
-    }
+        get() = getInternalNameOrNull()?.repoItemNameCompact ?: "<null>"
 
     /** Use when showing the item name to the user (in guis, chat message, etc.), not for comparing. */
     val SafeItemStack.itemNameWithoutColor: String get() = repoItemName.removeColor()


### PR DESCRIPTION
## What
Removes the legacy pre-Galatea item name logic for Attribute Shards that caused item display names to be e.g. `§bDivine Rabbit Luck 1 Shard` instead of `§5Rabbit Godmother Shard` in some places like the Chocolate Shop Price feature. These items have proper display names given by Hypixel instead of just "Attribute Shard", so no special logic is necessary anymore.

## Changelog Fixes
+ Fixed Attribute Shards not showing their proper names in some SkyHanni GUIs. - Luna