### PR TITLE
Fix: Stat renames corrupting profile storage

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 141
+    const val CONFIG_VERSION = 142
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null
@@ -117,6 +117,7 @@ object ConfigUpdaterMigrator {
                         "$realPrefix.${toPath.substringAfter('.')}", transform,
                     )
                 }
+                return
             }
             val oldElem = old.at(op, false)
             if (oldElem == null) {
@@ -165,6 +166,7 @@ object ConfigUpdaterMigrator {
                 for (realPrefix in realPrefixes) {
                     remove(since, "$realPrefix.${oldPath.substringAfter('.')}")
                 }
+                return
             }
             val oldElem = old.at(op, false)
             if (oldElem == null) {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -274,6 +274,12 @@ enum class SkyblockStat(
             event.move(112, "#profile.stats.NETHER_WART_FORTUNE", "#profile.stats.NETHER_STALK_FORTUNE")
             event.remove(113, "#profile.stats.null")
             event.move(141, "#profile.stats.HUNTER_FORTUNE", "#profile.stats.HUNTING_FORTUNE")
+            // Stats are stored under their lowercase name, so none of the renames above ever matched anything
+            event.move(142, "#profile.stats.true_defence", "#profile.stats.true_defense")
+            event.move(142, "#profile.stats.nether_wart_fortune", "#profile.stats.nether_stalk_fortune")
+            event.move(142, "#profile.stats.hunter_fortune", "#profile.stats.hunting_fortune")
+            // Left behind by stats that were read back while their rename was still missing
+            event.remove(142, "#profile.stats.unknown")
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/BaseGsonBuilder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/BaseGsonBuilder.kt
@@ -15,6 +15,7 @@ object BaseGsonBuilder {
         .registerTypeAdapterFactory(ShadowedFieldAdapterFactory)
         .registerTypeAdapterFactory(PropertyTypeAdapterFactory())
         .registerTypeAdapterFactory(KotlinTypeAdapterFactory())
+        .registerTypeAdapterFactory(SkyblockStatMapTypeAdapterFactory)
         .registerTypeAdapter(ChromaColour::class.java, LegacyStringChromaColourTypeAdapter(true).nullSafe())
         .registerSkyHanniAdapters()
         .enableComplexMapKeySerialization()

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
@@ -13,7 +13,8 @@ import java.lang.reflect.ParameterizedType
 /**
  * Drops map entries keyed by a stat name that no longer exists, as well as SkyblockStat.UNKNOWN itself.
  * Reading removed stats as UNKNOWN instead rewrites the stat under that name on the next save, and makes the
- * read of the entire file fail with a duplicate key error as soon as a second removed stat joins it.
+ * read fail with a duplicate key error as soon as a second removed stat joins it, causing a cascading
+ * resulting in the entirety of storage.players being deserialized as null.
  */
 object SkyblockStatMapTypeAdapterFactory : TypeAdapterFactory {
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
@@ -1,0 +1,55 @@
+package at.hannibal2.skyhanni.utils.json
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.model.SkyblockStat
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.reflect.ParameterizedType
+
+/*
+    Drops map entries keyed by a stat name that no longer exists, as well as SkyblockStat.UNKNOWN itself.
+    Reading removed stats as UNKNOWN instead rewrites the stat under that name on the next save, and makes the
+    read of the entire file fail with a duplicate key error as soon as a second removed stat joins it.
+ */
+object SkyblockStatMapTypeAdapterFactory : TypeAdapterFactory {
+
+    override fun <T : Any?> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
+        if (type.rawType != Map::class.java) return null
+        val arguments = (type.type as? ParameterizedType)?.actualTypeArguments ?: return null
+        if (arguments.first() != SkyblockStat::class.java) return null
+        @Suppress("UNCHECKED_CAST")
+        return Adapter(gson.getAdapter(TypeToken.get(arguments[1]))).nullSafe() as TypeAdapter<T>
+    }
+
+    private class Adapter<V>(private val valueAdapter: TypeAdapter<V>) : TypeAdapter<Map<SkyblockStat, V>>() {
+
+        override fun write(writer: JsonWriter, value: Map<SkyblockStat, V>) {
+            writer.beginObject()
+            for ((stat, statValue) in value) {
+                if (stat == SkyblockStat.UNKNOWN) continue
+                writer.name(stat.name.lowercase())
+                valueAdapter.write(writer, statValue)
+            }
+            writer.endObject()
+        }
+
+        override fun read(reader: JsonReader): Map<SkyblockStat, V> = LinkedHashMap<SkyblockStat, V>().apply {
+            reader.beginObject()
+            while (reader.hasNext()) {
+                val name = reader.nextName()
+                val stat = SkyblockStat.getValueOrNull(name.uppercase())?.takeIf { it != SkyblockStat.UNKNOWN }
+                if (stat == null) {
+                    SkyHanniMod.logger.warn("Dropping unknown stat '$name' while reading JSON")
+                    reader.skipValue()
+                    continue
+                }
+                put(stat, valueAdapter.read(reader))
+            }
+            reader.endObject()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyblockStatMapTypeAdapterFactory.kt
@@ -10,14 +10,14 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import java.lang.reflect.ParameterizedType
 
-/*
-    Drops map entries keyed by a stat name that no longer exists, as well as SkyblockStat.UNKNOWN itself.
-    Reading removed stats as UNKNOWN instead rewrites the stat under that name on the next save, and makes the
-    read of the entire file fail with a duplicate key error as soon as a second removed stat joins it.
+/**
+ * Drops map entries keyed by a stat name that no longer exists, as well as SkyblockStat.UNKNOWN itself.
+ * Reading removed stats as UNKNOWN instead rewrites the stat under that name on the next save, and makes the
+ * read of the entire file fail with a duplicate key error as soon as a second removed stat joins it.
  */
 object SkyblockStatMapTypeAdapterFactory : TypeAdapterFactory {
 
-    override fun <T : Any?> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
+    override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
         if (type.rawType != Map::class.java) return null
         val arguments = (type.type as? ParameterizedType)?.actualTypeArguments ?: return null
         if (arguments.first() != SkyblockStat::class.java) return null

--- a/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatStorageTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatStorageTest.kt
@@ -33,6 +33,19 @@ class SkyblockStatStorageTest {
     private val uuid = "0a2af95e-21cf-4ee2-8a96-e30352680646"
     private val profilePath = "storage.players.$uuid.profiles.pear"
 
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(69, "#profile.stats.TRUE_DEFENCE", "#profile.stats.TRUE_DEFENSE")
+        event.move(112, "#profile.stats.NETHER_WART_FORTUNE", "#profile.stats.NETHER_STALK_FORTUNE")
+        event.remove(113, "#profile.stats.null")
+        event.move(141, "#profile.stats.HUNTER_FORTUNE", "#profile.stats.HUNTING_FORTUNE")
+        // Stats are stored under their lowercase name, so none of the renames above ever matched anything
+        event.move(142, "#profile.stats.true_defence", "#profile.stats.true_defense")
+        event.move(142, "#profile.stats.nether_wart_fortune", "#profile.stats.nether_stalk_fortune")
+        event.move(142, "#profile.stats.hunter_fortune", "#profile.stats.hunting_fortune")
+        // Left behind by stats that were read back while their rename was still missing
+        event.remove(142, "#profile.stats.unknown")
+    }
+
     @Test
     fun `removed stats do not break reading the surrounding storage`() {
         // Mirrors ConfigManager, where a failed read is swallowed instead of resetting the config.
@@ -65,11 +78,11 @@ class SkyblockStatStorageTest {
         val event = ConfigUpdaterMigrator.ConfigFixEvent(
             old = old,
             new = JsonObject(),
-            oldVersion = ConfigUpdaterMigrator.CONFIG_VERSION - 1,
+            oldVersion = 141,
             movesPerformed = 0,
             dynamicPrefix = mapOf("#profile" to listOf(profilePath)),
         )
-        SkyblockStat.onConfigFix(event)
+        onConfigFix(event)
 
         val migrated = checkNotNull(event.new.at("$profilePath.stats".split("."), false) as? JsonObject) {
             "migration did not move any stats"

--- a/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatStorageTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatStorageTest.kt
@@ -1,0 +1,86 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator.at
+import at.hannibal2.skyhanni.data.model.SkyblockStat
+import at.hannibal2.skyhanni.utils.json.BaseGsonBuilder
+import at.hannibal2.skyhanni.utils.json.SkippingTypeAdapterFactory
+import com.google.gson.JsonObject
+import com.google.gson.annotations.Expose
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SkyblockStatStorageTest {
+
+    class Profile {
+        @Expose
+        var stats: MutableMap<SkyblockStat, Double?> = mutableMapOf()
+    }
+
+    class Player {
+        @Expose
+        var profiles: MutableMap<String, Profile> = mutableMapOf()
+    }
+
+    class Storage {
+        @Expose
+        var players: MutableMap<UUID, Player> = mutableMapOf()
+    }
+
+    private val uuid = "0a2af95e-21cf-4ee2-8a96-e30352680646"
+    private val profilePath = "storage.players.$uuid.profiles.pear"
+
+    @Test
+    fun `removed stats do not break reading the surrounding storage`() {
+        // Mirrors ConfigManager, where a failed read is swallowed instead of resetting the config.
+        val gson = BaseGsonBuilder.gson().registerTypeAdapterFactory(SkippingTypeAdapterFactory).create()
+        val json = """
+            {"players":{"$uuid":{"profiles":{"pear":{
+              "stats":{"strength":5.0,"hunter_fortune":121.0,"unknown":60.0,"speed":100.0}
+            }}}}}
+        """.trimIndent()
+
+        val storage = gson.fromJson(json, Storage::class.java)
+
+        val profile = storage.players.getValue(UUID.fromString(uuid)).profiles.getValue("pear")
+        assertEquals(mapOf(SkyblockStat.STRENGTH to 5.0, SkyblockStat.SPEED to 100.0), profile.stats)
+        assertEquals("""{"stats":{"strength":5.0,"speed":100.0}}""", gson.toJson(profile).filterNot { it.isWhitespace() })
+    }
+
+    @Test
+    fun `renamed stats are migrated`() {
+        val stats = JsonObject().apply {
+            addProperty("hunter_fortune", 121.0)
+            addProperty("nether_wart_fortune", 42.0)
+            addProperty("unknown", 60.0)
+            addProperty("strength", 5.0)
+        }
+        val old = JsonObject()
+        val profile = old.at(profilePath.split("."), true) as JsonObject
+        profile.add("stats", stats)
+
+        val event = ConfigUpdaterMigrator.ConfigFixEvent(
+            old = old,
+            new = JsonObject(),
+            oldVersion = ConfigUpdaterMigrator.CONFIG_VERSION - 1,
+            movesPerformed = 0,
+            dynamicPrefix = mapOf("#profile" to listOf(profilePath)),
+        )
+        SkyblockStat.onConfigFix(event)
+
+        val migrated = checkNotNull(event.new.at("$profilePath.stats".split("."), false) as? JsonObject) {
+            "migration did not move any stats"
+        }
+        assertEquals(121.0, migrated["hunting_fortune"].asDouble)
+        assertEquals(42.0, migrated["nether_stalk_fortune"].asDouble)
+        assertNull(migrated["unknown"])
+
+        assertFalse(stats.has("hunter_fortune"))
+        assertFalse(stats.has("nether_wart_fortune"))
+        assertFalse(stats.has("unknown"))
+        assertEquals(5.0, stats["strength"].asDouble)
+    }
+}


### PR DESCRIPTION
## What
Fixes broken stat migrations that never actually did anything corrupting the player's config by creating duplicate `UNKNOWN` keys once they go through two failed migrations (e.g. `NETHER_WART_FORTUNE` -> `NETHER_STALK_FORTUNE` & `HUNTER_FORTUNE` -> `HUNTING_FORTUNE`).

## Changelog Fixes
+ Fixed stat migrations sometimes corrupting the config when upgrading from an older version. - Luna