### PR TITLE
Fix: /shmouselock not unlocking when leaving the garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
@@ -110,18 +110,18 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onIslandJoin() {
         manualState = null
         autoState = null
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTick() {
+    private fun onTick() {
         updateAutoState()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (config.unlockOnTeleport != UnlockOnTeleport.NEVER && manualState != null) {
             teleportPattern.matchMatchers(event.cleanMessage) {
                 if (config.unlockOnTeleport.condition(group("plot"))) {
@@ -148,7 +148,7 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shmouselock") {
             description = "Lock/Unlock the mouse so it will no longer rotate the player (for farming)"
             category = CommandCategory.USERS_ACTIVE
@@ -175,7 +175,7 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (config.showGui) config.position.renderRenderable(
             when (activeState) {
                 null -> return
@@ -187,7 +187,7 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Mouse Sensitivity Reducer")
 
         if (activeState == null) event.addIrrelevant {
@@ -202,7 +202,7 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val oldBase = "garden.sensitivityReducer"
         val base = "garden.mouseSensitivityReducer"
         event.move(80, "garden.sensitivityReducerConfig", oldBase)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
@@ -110,7 +110,7 @@ object MouseSensitivityReducer {
     }
 
     @HandleEvent
-    private fun onIslandJoin() {
+    private fun onIslandLeave() {
         manualState = null
         autoState = null
     }


### PR DESCRIPTION
## What
using onWorldChange would not work because it takes time to recognize the new island,
so onTick would be called while leaving the garden and the mouse remains locked since.
Like:
onWorldChange runs, and THEN
onTick runs because the new island hasn't been registered yet so it still thinks we are in the garden.

I think? this is mostly a guess. got no proof really.

## Changelog Fixes
+ Fixed mouse locking sometimes not unlocking when leaving the Garden. - Avrg