### PR TITLE
Fix + Backend: Items sharing a display name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -121,6 +122,7 @@ class ItemResolutionQuery {
             var bestMatch: NeuInternalName? = null
             var bestMatchLength = -1
             loop@ for (internalName in candidateInternalNames.map { it.toInternalName() }) {
+                if (NeuItems.isIgnoredDisplayNameItem(internalName)) continue
                 val unCleanItemDisplayName: String = EnoughUpdatesManager.getDisplayName(internalName)
                 var cleanItemDisplayName = unCleanItemDisplayName.removeColor()
                 if (cleanItemDisplayName.isEmpty()) continue

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemDisplayNamesJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemDisplayNamesJson.kt
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.data.jsonobjects.repo
+
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @param ignoredInternalNames Items that lose the display name to another item.
+ * @param ambiguousDisplayNames Display names no item wins, written lowercase and with color codes.
+ */
+data class ItemDisplayNamesJson(
+    @Expose @SerializedName("ignored_internal_names") val ignoredInternalNames: Set<NeuInternalName>,
+    @Expose @SerializedName("ambiguous_display_names") val ambiguousDisplayNames: Set<String>,
+    @Expose val description: String,
+)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -1,9 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.api.enoughupdates.ItemResolutionQuery
-import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.SkyblockStat
-import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
@@ -20,6 +18,9 @@ object ItemNameResolver {
 
     @Suppress("ReturnCount", "CyclomaticComplexMethod")
     internal fun getInternalNameOrNull(itemName: String): NeuInternalName? {
+        // Without this the fallback below would resolve the name anyway, just to a random candidate.
+        if (NeuItems.isAmbiguousDisplayName(itemName)) return null
+
         val lowercase = itemName.lowercase()
         itemNameCache[lowercase]?.let {
             return it
@@ -144,8 +145,7 @@ object ItemNameResolver {
         return NeuItems.allItemsCache.filter { it.key.removeColor() == removeColor }.values.firstOrNull()
     }
 
-    @HandleEvent(NeuRepositoryReloadEvent::class)
-    fun onNeuRepoReload() {
+    internal fun clearCache() {
         itemNameCache.clear()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -87,6 +87,10 @@ value class NeuInternalName private constructor(private val internalName: String
 
         private val itemNameCache = mutableMapOf<String, NeuInternalName?>()
 
+        internal fun clearItemNameCache() {
+            itemNameCache.clear()
+        }
+
         fun fromItemNameOrNull(itemName: String): NeuInternalName? = itemNameCache.getOrPut(itemName) {
             ItemNameResolver.getInternalNameOrNull(itemName.removeSuffix(" Pet")) ?: getCoins(itemName)
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.enoughupdates.ItemResolutionQuery
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemAliases
+import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemDisplayNamesJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.MultiFilterJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuItemJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -14,9 +15,10 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getRepoItemNameFromJson
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuItems.allItemsCache
+import at.hannibal2.skyhanni.utils.NeuItems.ambiguousDisplayNames
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isVanillaItem
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeNonAsciiNonColorCode
@@ -41,6 +43,20 @@ object NeuItems {
     private val itemIdCache = mutableMapOf<Item, List<NeuInternalName>>()
     private val stackResolutionCache: TimeLimitedCache<NeuInternalName, SafeItemStack> = TimeLimitedCache(2.minutes)
     private val patternGroup = RepoPattern.group("data.neu.items")
+
+    // Internal names excluded from the display name to internal name lookup, because another item uses the same display name.
+    private var ignoredDisplayNames = emptySet<NeuInternalName>()
+
+    internal fun isIgnoredDisplayNameItem(internalName: NeuInternalName): Boolean = internalName in ignoredDisplayNames
+
+    /**
+     * Display names shared by several items where none of them is the one obviously meant.
+     * Resolving them would silently pick a random one, so they resolve to null instead.
+     */
+    private var ambiguousDisplayNames = emptySet<String>()
+
+    /** Callers without color codes, e.g. chat messages, must be caught as well. */
+    private var ambiguousDisplayNamesColorless = emptySet<String>()
 
     /**
      * WRAPPED-REGEX-TEST: "§7[lvl 1➡100] "
@@ -75,30 +91,50 @@ object NeuItems {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val ignoredItems = event.getConstant<MultiFilterJson>("IgnoredItems")
         ignoreItemsFilter.load(ignoredItems)
         commonItemAliases = event.getConstant<ItemAliases>("ItemAliases")
+        val displayNameData = event.getConstant<ItemDisplayNamesJson>("ItemDisplayNames")
+        ignoredDisplayNames = displayNameData.ignoredInternalNames
+        ambiguousDisplayNames = displayNameData.ambiguousDisplayNames.mapTo(mutableSetOf()) { normalizeDisplayName(it) }
+        ambiguousDisplayNamesColorless = ambiguousDisplayNames.mapTo(mutableSetOf()) { it.removeColor() }
+
+        // The neu repo may have loaded first, in which case the name cache was built without the list above.
+        if (allInternalNames.isNotEmpty()) DelayedRun.runOrNextTick(::readAllNeuItems)
     }
 
     @HandleEvent
-    fun onNeuRepoReload() {
+    private fun onNeuRepoReload() {
         multiplierCache.clear()
         itemIdCache.clear()
         DelayedRun.runOrNextTick(::readAllNeuItems)
+    }
+
+    /** The form display names are stored in, both in [allItemsCache] and in [ambiguousDisplayNames]. */
+    internal fun normalizeDisplayName(displayName: String): String =
+        displayName.lowercase().removeNonAsciiNonColorCode().trim()
+
+    internal fun isAmbiguousDisplayName(displayName: String): Boolean {
+        val name = normalizeDisplayName(displayName)
+        return name in ambiguousDisplayNames || name.removeColor() in ambiguousDisplayNamesColorless
     }
 
     private fun readAllNeuItems() {
         allInternalNames.clear()
         val tempAllItemCache = mutableMapOf<String, NeuInternalName>()
         val tempNoColor = TreeMap<String, NeuInternalName>()
+        val duplicates = mutableMapOf<String, MutableList<NeuInternalName>>()
 
         allNeuRepoItems().forEach { (internalName, itemInfo) ->
-            // we ignore all builder blocks from the item name -> internal name cache
-            // because builder blocks can have the same display name as normal items.
-            if (internalName.startsWith("BUILDER_")) return@forEach
-
             allInternalNames[internalName.asString()] = internalName
+
+            // Items sharing their display name with another item, where the other one is the one we want.
+            if (internalName in ignoredDisplayNames) return@forEach
+
+            // Every ignored item is named "§cBugged Item", see ItemUtils.getSpecialRepoItemName.
+            if (ignoreItemsFilter.match(internalName.asString())) return@forEach
+
             val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelRegex)?.takeIf {
                 it.isNotEmpty()
             } ?: run {
@@ -111,15 +147,35 @@ object NeuItems {
                 else println("wrong name: '$cleanName'")
             }
 
-            val newCleanName = cleanName.removeNonAsciiNonColorCode().trim()
+            val newCleanName = normalizeDisplayName(cleanName)
+            if (newCleanName in ambiguousDisplayNames) return@forEach
 
-            tempAllItemCache[newCleanName] = internalName
+            tempAllItemCache.put(newCleanName, internalName)?.let { previous ->
+                duplicates.getOrPut(newCleanName) { mutableListOf(previous) }.add(internalName)
+            }
             tempNoColor[newCleanName.removeColor()] = internalName
         }
         itemNamesWithoutColor = tempNoColor
         allItemsCache = tempAllItemCache
         stackResolutionCache.clear()
+        // These resolve through allItemsCache, so they have to follow every rebuild, not just the neu repo event.
+        ItemNameResolver.clearCache()
+        NeuInternalName.clearItemNameCache()
         ChatUtils.debug("Cleared the NEUItems stack resolution cache")
+        reportDuplicateDisplayNames(duplicates)
+    }
+
+    /**
+     * Which of them wins depends on the iteration order of the neu repo, so it can silently
+     * change with a repo update. Anything reported here belongs into ItemDisplayNames.
+     */
+    private fun reportDuplicateDisplayNames(duplicates: Map<String, List<NeuInternalName>>) {
+        if (duplicates.isEmpty()) return
+        ChatUtils.debug("Found ${duplicates.size} duplicate item display names, see console for details.")
+        for ((displayName, internalNames) in duplicates.toSortedMap()) {
+            val all = internalNames.joinToString(", ") { it.asString() }
+            println("duplicate item display name '$displayName': $all")
+        }
     }
 
     fun getInternalName(itemStack: SafeItemStack): NeuInternalName? = ItemResolutionQuery()
@@ -131,10 +187,6 @@ object NeuItems {
         val internalName = hypixelId.replace(':', '-')
         return internalName.toInternalName().takeIf { it.getItemStackOrNull() != null }
     }
-
-    fun getInternalNameFromHypixelId(hypixelId: String): NeuInternalName =
-        getInternalNameFromHypixelIdOrNull(hypixelId)
-            ?: error("hypixel item id does not match internal name: $hypixelId")
 
     fun transHypixelNameToInternalName(hypixelId: String): NeuInternalName =
         ItemResolutionQuery.transformHypixelBazaarToNeuItemId(hypixelId).toInternalName()
@@ -229,18 +281,7 @@ object NeuItems {
 
             val map = mutableMapOf<NeuInternalName, Int>()
             for (ingredient in recipe.ingredients) {
-                var internalItemId = ingredient.internalName
-                // ignore cactus green
-                if (internalName == "ENCHANTED_CACTUS_GREEN".toInternalName() && internalItemId == "INK_SACK-2".toInternalName()) {
-                    internalItemId = "CACTUS".toInternalName()
-                }
-
-                // ignore rabbit hide in leather
-                if (internalName == "LEATHER".toInternalName() && internalItemId == "RABBIT_HIDE".toInternalName()) {
-                    continue
-                }
-
-                map.addOrPut(internalItemId, ingredient.count.toInt())
+                addRecipeIngredient(ingredient, internalName, map)
             }
             if (map.size != 1) continue
             val current = map.iterator().next().toPair()
@@ -258,6 +299,25 @@ object NeuItems {
         val result = internalName.makePrimitiveStack()
         multiplierCache[internalName] = result
         return result
+    }
+
+    private fun addRecipeIngredient(
+        ingredient: PrimitiveIngredient,
+        resultInternalName: NeuInternalName,
+        map: MutableMap<NeuInternalName, Int>,
+    ) {
+        var internalItemId = ingredient.internalName
+        // ignore cactus green
+        if (resultInternalName == "ENCHANTED_CACTUS_GREEN".toInternalName() && internalItemId == "INK_SACK-2".toInternalName()) {
+            internalItemId = "CACTUS".toInternalName()
+        }
+
+        // ignore rabbit hide in leather
+        if (resultInternalName == "LEATHER".toInternalName() && internalItemId == "RABBIT_HIDE".toInternalName()) {
+            return
+        }
+
+        map.addOrPut(internalItemId, ingredient.count.toInt())
     }
 
     fun getRecipes(internalName: NeuInternalName): Set<PrimitiveRecipe> = EnoughUpdatesManager.getRecipesFor(internalName)
@@ -279,7 +339,7 @@ object NeuItems {
                 "Could not parse NEU item from encoded string",
                 internalMessage = "Could not load NEU item from encoded string - GSON parsing failed",
                 "encoded" to encoded,
-                "jsonString" to jsonString
+                "jsonString" to jsonString,
             )
             return ItemUtils.createItemStack(Items.MAP, "unloaded")
         }


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/829

## What
Two NEU repo items can share the exact same display name, here `§9Cropshot Chip`:

- [TUTORIAL_GARDEN_CHIP](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/blob/12f7726977b58e4a57cf4166ae0293bb90799a2d/items/TUTORIAL_GARDEN_CHIP.json)
- [CROPSHOT_GARDEN_CHIP](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/blob/12f7726977b58e4a57cf4166ae0293bb90799a2d/items/CROPSHOT_GARDEN_CHIP.json)

Which one wins depended on the NEU repo iteration order and could change with any repo update. Here the tutorial version won over the normal one.

Two repo lists replace the hardcoded builder block check: `ignored_internal_names` drops an item so the other one wins, `ambiguous_display_names` drops a name entirely where no candidate is the one meant. Both also apply to the mangled name fallback in `ItemResolutionQuery`. Remaining collisions are printed to the console on repo load.

## Changelog Fixes
+ Fixed Cropshot Chip being detected as the wrong item. - hannibal2

## Changelog Technical Details
+ Moved the display name lookup exclusions into the repo. - hannibal2
+ Added a console log for duplicate item display names. - hannibal2
+ Removed the unused getInternalNameFromHypixelId. - hannibal2
