### PR TITLE
Feature: Hide Order Owner and Trade Partners in the Bazaar

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
@@ -24,6 +24,26 @@ class BazaarConfig {
     var orderHelper: Boolean = false
 
     @Expose
+    @ConfigOption(
+        name = "Hide Order Owner",
+        desc = "Hide the §eBy: §7line in the Bazaar order inventory, but only while every order and offer in it is your own.\n" +
+            "Hypixel only sends that line while you are in a co-op.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideOrderOwner: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Hide Trade Partners",
+        desc = "Hide the list of players that traded with your orders in the Bazaar order inventory.\n" +
+            "Buy orders show them under §eVendors§7, sell offers under §eCustomers§7.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideTradePartners: Boolean = false
+
+    @Expose
     @ConfigOption(name = "Best Sell Method", desc = "Show the price difference between sell instantly and sell offer.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderApi.kt
@@ -92,7 +92,7 @@ object BazaarOrderApi {
      * REGEX-TEST: By: [MVP+] hannibal2
      * REGEX-TEST: By: hannibal2
      */
-    private val ownerPattern by patternGroup.pattern(
+    val ownerPattern by patternGroup.pattern(
         "owner.colorless",
         "By: (?:\\[[^]]+] )?(?<name>\\S+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderTooltip.kt
@@ -1,0 +1,71 @@
+package at.hannibal2.skyhanni.features.inventory.bazaar
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.bazaar.BazaarOrdersLoadedEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.network.chat.Component
+
+/**
+ * Hides redundant lines from the item tooltips inside the bazaar order inventory.
+ */
+@SkyHanniModule
+object BazaarOrderTooltip {
+
+    private val config get() = SkyHanniMod.feature.inventory.bazaar
+
+    private val patternGroup = RepoPattern.group("bazaar.orders.tooltip")
+
+    /**
+     * Buy orders name the sellers, sell offers name the buyers, and both switch to a singular
+     * header while only one player is involved.
+     *
+     * REGEX-TEST: Vendors:
+     * REGEX-TEST: Single vendor:
+     * REGEX-TEST: Customers:
+     * REGEX-TEST: Single customer:
+     */
+    private val tradePartnerHeaderPattern by patternGroup.pattern(
+        "tradepartners.colorless",
+        "(?:Vendors|Single vendor|Customers|Single customer):",
+    )
+
+    private var allOrdersOwn = false
+
+    @HandleEvent
+    private fun onBazaarOrdersLoaded(event: BazaarOrdersLoadedEvent) {
+        allOrdersOwn = event.orders.all { it.isOwn }
+    }
+
+    @HandleEvent
+    private fun onInventoryClose() {
+        allOrdersOwn = false
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onToolTip(event: ToolTipTextEvent) {
+        if (!BazaarOrderApi.inOrderInventory()) return
+
+        if (config.hideTradePartners) {
+            event.toolTip.removeBlock { tradePartnerHeaderPattern.matches(it) }
+        }
+        // The owner only says something useful while a co-op member has orders in here as well.
+        if (config.hideOrderOwner && allOrdersOwn) {
+            event.toolTip.removeBlock { BazaarOrderApi.ownerPattern.matches(it) }
+        }
+    }
+
+    /**
+     * Removes the block starting at the line matching [isHeader], up to and including the empty
+     * line that follows it. A block at the end of the tooltip has none and is removed to the end.
+     */
+    private fun MutableList<Component>.removeBlock(isHeader: (Component) -> Boolean) {
+        val start = indexOfFirst(isHeader).takeIf { it != -1 } ?: return
+        var end = start
+        while (end < size && this[end].string.isNotBlank()) end++
+        subList(start, (end + 1).coerceAtMost(size)).clear()
+    }
+}


### PR DESCRIPTION
<details>
<summary>Images</summary>

<img width="517" height="374" alt="image" src="https://github.com/user-attachments/assets/55a7e292-daab-4a69-8238-71bdc2817754" />

<img width="392" height="334" alt="image" src="https://github.com/user-attachments/assets/3c4df242-df9d-4c0e-9636-2b10860f1a91" />


</details>

## Changelog New Features
+ Added Hide Order Owner. - hannibal2
    * Hides the `By:` line in the Bazaar order inventory, but only while every order and offer in it belongs to you.
    * Hypixel only sends that line while you are in a Co-op.
+ Added Hide Trade Partners. - hannibal2
    * Hides the list of players that traded with your Bazaar orders and offers.