### PR TITLE
Feature + Fix: NPC Trade Helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.features.inventory.customloadout.CustomLoado
 import at.hannibal2.skyhanni.config.features.inventory.customwardrobe.CustomWardrobeConfig
 import at.hannibal2.skyhanni.config.features.inventory.experimentationtable.ExperimentationTableConfig
 import at.hannibal2.skyhanni.config.features.inventory.helper.HelperConfig
+import at.hannibal2.skyhanni.config.features.inventory.npctrade.NpcTradeConfig
 import at.hannibal2.skyhanni.config.features.inventory.sacks.OutsideSackValueConfig
 import at.hannibal2.skyhanni.config.features.itemability.ItemAbilityConfig
 import at.hannibal2.skyhanni.config.features.misc.EstimatedItemValueConfig
@@ -182,10 +183,16 @@ class InventoryConfig {
     @SearchTag(EVOLVING_ITEMS_SEARCH_TAG)
     val evolvingItems: EvolvingItemsConfig = EvolvingItemsConfig()
 
+    // TODO rename to playerTrade
     @Expose
-    @ConfigOption(name = "Trade Value", desc = "Creates a trade value overlay")
+    @ConfigOption(name = "Player Trade", desc = "Creates a trade value overlay")
     @Accordion
-    val trade: TradeConfig = TradeConfig()
+    val trade: PlayerTradeConfig = PlayerTradeConfig()
+
+    @Expose
+    @ConfigOption(name = "NPC Trade", desc = "")
+    @Accordion
+    val npcTrade: NpcTradeConfig = NpcTradeConfig()
 
     @Expose
     @ConfigOption(name = "Item Number", desc = "Show the item number as a stack size for these items.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/PlayerTradeConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/PlayerTradeConfig.kt
@@ -7,21 +7,21 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class TradeConfig {
+class PlayerTradeConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Displays an overlay showing the total combined value of the trade",
+        desc = "Displays an overlay showing the total combined value of the trade between two players.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false
 
     @Expose
-    @ConfigLink(owner = TradeConfig::class, field = "enabled")
+    @ConfigLink(owner = PlayerTradeConfig::class, field = "enabled")
     val otherPosition: Position = Position(-300, 140)
 
     @Expose
-    @ConfigLink(owner = TradeConfig::class, field = "enabled")
+    @ConfigLink(owner = PlayerTradeConfig::class, field = "enabled")
     val yourPosition: Position = Position(212, 140)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/npctrade/NpcTradeConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/npctrade/NpcTradeConfig.kt
@@ -1,0 +1,27 @@
+package at.hannibal2.skyhanni.config.features.inventory.npctrade
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class NpcTradeConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Highlight Affordable",
+        desc = "Highlight items in NPC trade menus that you can buy right now.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var highlightAffordable: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Cost Breakdown",
+        desc = "Show the price, how much you own and the total cost in the item lore.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var costBreakdown: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
@@ -14,18 +14,15 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
@@ -48,21 +45,13 @@ object FishyTreatProfit {
 
     private val patternGroup = RepoPattern.group("event.year-of-the-seal.fishy-treat")
 
-    /**
-     * REGEX-TEST: §62,000,000 Coins
-     */
-    private val coinsPattern by patternGroup.pattern(
-        "coins",
-        "§6(?<coins>.*) Coins",
-    )
-
     private val inventoryNamePattern by patternGroup.pattern(
         "inventory",
         "Lukas the Aquarist",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!config.fishyTreatProfit || !inventory.isInside()) return
         val table = mutableListOf<DisplayTableEntry>()
         for ((slot, item) in event.inventoryItems) {
@@ -91,7 +80,7 @@ object FishyTreatProfit {
 
     private fun readItem(slot: Int, item: SafeItemStack, table: MutableList<DisplayTableEntry>) {
         val itemName = getItemName(item)
-        val allMaterials = getAdditionalMaterials(getRequiredItems(item))
+        val allMaterials = item.readLoreCosts().associate { it.internalName to it.amount }
         val additionalMaterials = allMaterials.filter { it.key != FISHY_TREAT }
         val amountOfFishyTreat = allMaterials[FISHY_TREAT] ?: run {
             ErrorManager.logErrorStateWithData(
@@ -151,7 +140,7 @@ object FishyTreatProfit {
         )
     }
 
-    private fun MutableList<Any>.addAdditionalMaterials(additionalMaterials: Map<NeuInternalName, Int>) {
+    private fun MutableList<Any>.addAdditionalMaterials(additionalMaterials: Map<NeuInternalName, Long>) {
         for ((internalName, amount) in additionalMaterials) {
             add(internalName.getPriceName(amount, internalName.getPrice(priceSource)))
         }
@@ -165,57 +154,12 @@ object FishyTreatProfit {
         } else name
     }
 
-    private fun getAdditionalMaterials(requiredItems: Map<String, Int>): Map<NeuInternalName, Int> {
-        val additionalMaterials = mutableMapOf<NeuInternalName, Int>()
-        for ((name, amount) in requiredItems) {
-            coinsPattern.matchMatcher(name) {
-                additionalMaterials[NeuInternalName.SKYBLOCK_COIN] = group("coins").formatInt()
-            } ?: run {
-                additionalMaterials[NeuInternalName.fromItemName(name)] = amount
-            }
-        }
-        return additionalMaterials
-    }
-
-    private fun getAdditionalCost(requiredItems: Map<NeuInternalName, Int>): Double {
+    private fun getAdditionalCost(requiredItems: Map<NeuInternalName, Long>): Double {
         var otherItemsPrice = 0.0
         for ((name, amount) in requiredItems) {
             otherItemsPrice += name.getPrice(priceSource) * amount
         }
         return otherItemsPrice
-    }
-
-    private fun getRequiredItems(item: SafeItemStack): MutableMap<String, Int> {
-        val items = mutableMapOf<String, Int>()
-        var next = false
-        val lore = item.getLore()
-        for (line in lore) {
-            if (line == "§7Cost") {
-                next = true
-                continue
-            }
-            if (next) {
-                if (line == "") {
-                    next = false
-                    continue
-                }
-
-                val rawItemName = line.replace("§8 ", " §8")
-
-                val pair = ItemUtils.readItemAmount(rawItemName)
-                if (pair == null) {
-                    ErrorManager.logErrorStateWithData(
-                        "Error in FishyTreat Profit", "Could not read item amount",
-                        "rawItemName" to rawItemName,
-                        "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
-                        "lore" to lore,
-                    )
-                    continue
-                }
-                items.add(pair)
-            }
-        }
-        return items
     }
 
     init {

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -10,19 +10,16 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
-import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
@@ -36,7 +33,9 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SignUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -71,7 +70,7 @@ object CityProjectFeatures {
     )
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed() {
         if (!config.dailyReminder) return
         val playerSpecific = ProfileStorageData.playerSpecific ?: return
         if (ReminderUtils.isBusy()) return
@@ -102,15 +101,15 @@ object CityProjectFeatures {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
 
         inInventory = false
-        if (!inCityProject(event)) return
+        if (!inCityProject(event.inventoryItems)) return
         inInventory = true
 
         if (config.showMaterials) {
@@ -125,37 +124,41 @@ object CityProjectFeatures {
         }
 
         if (config.showReady) {
-            var nextTime = SimpleTimeMark.farFuture()
-            val now = SimpleTimeMark.now()
-            for ((_, item) in event.inventoryItems) {
-
-                val lore = item.getLore()
-                val completed = lore.lastOrNull()?.let { completedPattern.matches(it) } ?: false
-                if (completed) continue
-                contributeAgainPattern.firstMatcher(lore) {
-                    val rawTime = group("time")
-                    val duration = if (rawTime.contains("Soon!")) {
-                        5.seconds
-                    } else {
-                        // hypixel rounds down to the next full minute, it shows "1m" when it is in fact 1-2 minutes, and "0m" for the last 60s
-                        TimeUtils.getDuration(rawTime).let {
-                            if (it < 1.hours) it + 1.minutes else it
-                        }
-                    }
-                    val endTime = now + duration
-                    if (endTime < nextTime) {
-                        nextTime = endTime
-                    }
-                }
-                if (item.hoverName.string != "Contribute this component!") continue
-                nextTime = now
-            }
-            ProfileStorageData.playerSpecific?.nextCityProjectParticipationTime = nextTime
+            showWhenReady(event.inventoryItems)
         }
     }
 
-    private fun inCityProject(event: InventoryFullyOpenedEvent): Boolean {
-        val lore = event.inventoryItems[4]?.getLore() ?: return false
+    private fun showWhenReady(inventoryItems: Map<Int, SafeItemStack>) {
+        var nextTime = SimpleTimeMark.farFuture()
+        val now = SimpleTimeMark.now()
+        for ((_, item) in inventoryItems) {
+
+            val lore = item.getLore()
+            val completed = lore.lastOrNull()?.let { completedPattern.matches(it) } ?: false
+            if (completed) continue
+            contributeAgainPattern.firstMatcher(lore) {
+                val rawTime = group("time")
+                val duration = if (rawTime.contains("Soon!")) {
+                    5.seconds
+                } else {
+                    // hypixel rounds down to the next full minute, it shows "1m" when it is in fact 1-2 minutes, and "0m" for the last 60s
+                    TimeUtils.getDuration(rawTime).let {
+                        if (it < 1.hours) it + 1.minutes else it
+                    }
+                }
+                val endTime = now + duration
+                if (endTime < nextTime) {
+                    nextTime = endTime
+                }
+            }
+            if (item.hoverName.string != "Contribute this component!") continue
+            nextTime = now
+        }
+        ProfileStorageData.playerSpecific?.nextCityProjectParticipationTime = nextTime
+    }
+
+    private fun inCityProject(inventoryItems: Map<Int, SafeItemStack>): Boolean {
+        val lore = inventoryItems[4]?.getLore() ?: return false
         if (lore.isEmpty()) return false
         if (lore[0] != "§8City Project") return false
         return true
@@ -199,29 +202,17 @@ object CityProjectFeatures {
     ) { inInventory }
 
     private fun fetchMaterials(item: SafeItemStack, materials: MutableMap<NeuInternalName, Int>) {
-        var next = false
-        val lore = item.getLore()
-        val completed = lore.lastOrNull()?.let { completedPattern.matches(it) } ?: false
+        val completed = item.getLore().lastOrNull()?.let { completedPattern.matches(it) } ?: false
         if (completed) return
-        // TODO: Refactor this loop to not have so many jumps
-        @Suppress("LoopWithTooManyJumpStatements")
-        for (line in lore) {
-            if (line == "§7Cost") {
-                next = true
-                continue
-            }
-            if (!next) continue
-            if (line == "" || line.contains("Bits")) break
 
-            val (name, amount) = ItemUtils.readItemAmount(line) ?: continue
-            val internalName = NeuInternalName.fromItemName(name)
-            val old = materials.getOrPut(internalName) { 0 }
-            materials[internalName] = old + amount
+        for ((internalName, amount) in item.readLoreCosts()) {
+            if (internalName == SkyblockCurrency.BITS.internalName) continue
+            materials.addOrPut(internalName, amount.toInt())
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (!config.showMaterials) return
         if (!inInventory) return
 
@@ -231,7 +222,7 @@ object CityProjectFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    private fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!config.showReady) return
         if (!inInventory) return
 
@@ -249,7 +240,7 @@ object CityProjectFeatures {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "misc.cityProject", "event.cityProject")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.foraging
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -12,18 +11,15 @@ import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
@@ -42,13 +38,13 @@ object StarlynSisterCouponProfit {
     private var currentSisterType: StarlynSisterType? = null
 
     @HandleEvent
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         currentSisterType = null
         display = emptyList()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!config.starlynCouponProfitEnabled) return
         StarlynSisterType.entries.forEach { sisterType ->
             if (event.inventoryName == sisterType.inventoryName) currentSisterType = sisterType
@@ -80,7 +76,7 @@ object StarlynSisterCouponProfit {
     private fun readItem(slot: Int, item: SafeItemStack): DisplayTableEntry? {
         if (!isValidSlotNumber(slot)) return null
         val (internalName, itemName) = workOutInternalNameOrNull(item) ?: return null
-        val requiredItems = getRequiredItems(item)
+        val requiredItems = item.readLoreCosts()
         val price = internalName.getPrice()
         var totalCost = 0.0
         var couponAmount = 0
@@ -88,7 +84,7 @@ object StarlynSisterCouponProfit {
             val itemPrice = name.getPriceOrNull() ?: continue
             totalCost += itemPrice * amount
             if (name == currentSisterType?.couponName) {
-                couponAmount = amount
+                couponAmount = amount.toInt()
             }
         }
         val profit = price - totalCost
@@ -131,33 +127,6 @@ object StarlynSisterCouponProfit {
         }
     }
 
-    private fun getRequiredItems(item: SafeItemStack): MutableMap<NeuInternalName, Int> {
-        val items = mutableMapOf<NeuInternalName, Int>()
-
-        val lore = item.getLore()
-        val costLines = lore
-            .sublistAfter({ it == "§7Cost" }, skip = 1, amount = lore.size)
-            .takeWhile { it.isNotEmpty() }
-
-        for (line in costLines) {
-            val rawItemName = line.replace("§8 ", " §8")
-
-            val originalPair = ItemUtils.readItemAmount(rawItemName)
-            if (originalPair == null) {
-                ErrorManager.logErrorStateWithData(
-                    "Error in StarlynSisterCouponProfit", "Could not read item amount",
-                    "rawItemName" to rawItemName,
-                    "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
-                    "lore" to lore,
-                )
-                continue
-            }
-            val newPair = NeuInternalName.fromItemName(originalPair.first) to originalPair.second
-            items.add(newPair)
-        }
-        return items
-    }
-
     private fun isValidSlotNumber(slot: Int): Boolean {
         if (slot !in 9..44) return false
         val modNine = slot % 9
@@ -165,7 +134,7 @@ object StarlynSisterCouponProfit {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (currentSisterType == null) return
         config.starlynCouponProfitPos.renderRenderables(
             display,
@@ -175,7 +144,7 @@ object StarlynSisterCouponProfit {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(139, "foraging.starlynContest.agathaCouponProfitEnabled", "foraging.starlynContest.starlynCouponProfitEnabled")
         event.move(139, "foraging.starlynContest.agathaCouponProfitPos", "foraging.starlynContest.starlynCouponProfitPos")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -16,17 +14,17 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
@@ -43,30 +41,34 @@ object AnitaMedalProfit {
     var inInventory = false
 
     enum class MedalType(
-        val displayName: String,
-        val simpleName: String = displayName.removeColor().split(" ")[0],
+        val simpleName: String,
         val factorBronze: Int,
-        val color: LorenzColor = displayName.substring(1, 2)[0].toLorenzColor() ?: LorenzColor.WHITE,
+        val currency: SkyblockCurrency,
     ) {
-        GOLD("§6Gold medal", "gold", 8),
-        SILVER("§fSilver medal", "silver", 2),
-        BRONZE("§cBronze medal", "bronze", 1),
+        GOLD("gold", 8, SkyblockCurrency.GOLD_MEDAL),
+        SILVER("silver", 2, SkyblockCurrency.SILVER_MEDAL),
+        BRONZE("bronze", 1, SkyblockCurrency.BRONZE_MEDAL),
         ;
 
+        val displayName = currency.displayName
+
+        val color: LorenzColor = displayName.substring(1, 2)[0].toLorenzColor() ?: LorenzColor.WHITE
+
         companion object {
-            fun bySimpleNameOrNull(name: String) = entries.firstOrNull { it.simpleName == name }
+            fun bySimpleNameOrNull(name: String): MedalType? = entries.firstOrNull { it.simpleName == name }
+
+            fun getByInternalNameOrNull(internalName: NeuInternalName): MedalType? =
+                entries.firstOrNull { it.currency.internalName == internalName }
         }
     }
 
-    private fun getMedal(name: String) = MedalType.entries.firstOrNull { it.displayName == name }
-
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
     }
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!config.medalProfitEnabled) return
         if (event.inventoryName != "Anita") return
         if (VisitorApi.inInventory) return
@@ -97,7 +99,7 @@ object AnitaMedalProfit {
         val itemName = getItemName(item)
         if (isInvalidItemName(itemName.string)) return
 
-        val requiredItems = getRequiredItems(item)
+        val requiredItems = item.readLoreCosts()
         val additionalMaterials = getAdditionalMaterials(requiredItems)
         val additionalCost = getAdditionalCost(additionalMaterials)
 
@@ -172,16 +174,9 @@ object AnitaMedalProfit {
         } else name
     }
 
-    private fun getAdditionalMaterials(requiredItems: Map<String, Int>): Map<NeuInternalName, Int> {
-        val additionalMaterials = mutableMapOf<NeuInternalName, Int>()
-        for ((name, amount) in requiredItems) {
-            val medal = getMedal(name)
-            if (medal == null) {
-                additionalMaterials[NeuInternalName.fromItemName(name)] = amount
-            }
-        }
-        return additionalMaterials
-    }
+    private fun getAdditionalMaterials(requiredItems: List<LoreCostUtils.LoreCostEntry>): Map<NeuInternalName, Int> =
+        requiredItems.filter { MedalType.getByInternalNameOrNull(it.internalName) == null }
+            .associate { it.internalName to it.amount.toInt() }
 
     private fun getAdditionalCost(requiredItems: Map<NeuInternalName, Int>): Double {
         var otherItemsPrice = 0.0
@@ -191,50 +186,17 @@ object AnitaMedalProfit {
         return otherItemsPrice
     }
 
-    private fun getBronzeCost(requiredItems: Map<String, Int>): Int? {
-        for ((name, amount) in requiredItems) {
-            getMedal(name)?.let {
-                return it.factorBronze * amount
+    private fun getBronzeCost(requiredItems: List<LoreCostUtils.LoreCostEntry>): Int? {
+        for (entry in requiredItems) {
+            MedalType.getByInternalNameOrNull(entry.internalName)?.let {
+                return it.factorBronze * entry.amount.toInt()
             }
         }
         return null
     }
 
-    private fun getRequiredItems(item: SafeItemStack): MutableMap<String, Int> {
-        val items = mutableMapOf<String, Int>()
-        var next = false
-        val lore = item.getLore()
-        for (line in lore) {
-            if (line == "§7Cost") {
-                next = true
-                continue
-            }
-            if (next) {
-                if (line == "") {
-                    next = false
-                    continue
-                }
-
-                val rawItemName = line.replace("§8 ", " §8")
-
-                val pair = ItemUtils.readItemAmount(rawItemName)
-                if (pair == null) {
-                    ErrorManager.logErrorStateWithData(
-                        "Error in Anita Medal Contest", "Could not read item amount",
-                        "rawItemName" to rawItemName,
-                        "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
-                        "lore" to lore,
-                    )
-                    continue
-                }
-                items.add(pair)
-            }
-        }
-        return items
-    }
-
     @HandleEvent
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (!inInventory || VisitorApi.inInventory) return
         config.medalProfitPos.renderRenderables(
             display,
@@ -244,7 +206,7 @@ object AnitaMedalProfit {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "garden.anitaMedalProfitEnabled", "garden.anitaShop.medalProfitEnabled")
         event.move(3, "garden.anitaMedalProfitPos", "garden.anitaShop.medalProfitPos")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LoreCostUtils
 import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -50,9 +49,7 @@ object AnitaMedalProfit {
         BRONZE("bronze", 1, SkyblockCurrency.BRONZE_MEDAL),
         ;
 
-        val displayName = currency.displayName
-
-        val color: LorenzColor = displayName.substring(1, 2)[0].toLorenzColor() ?: LorenzColor.WHITE
+        val color: LorenzColor get() = currency.color
 
         companion object {
             fun bySimpleNameOrNull(name: String): MedalType? = entries.firstOrNull { it.simpleName == name }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.garden.inventory
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -12,41 +10,32 @@ import at.hannibal2.skyhanni.utils.DisplayTableEntry
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.loreCosts
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonPrimitive
 
 @SkyHanniModule
 object SkyMartCopperPrice {
-
-    /**
-     * REGEX-TEST: §c250 Copper
-     */
-    private val copperPattern by RepoPattern.pattern(
-        "garden.inventory.skymart.copper",
-        "§c(?<amount>.*) Copper",
-    )
 
     private var display = emptyList<Renderable>()
     private val config get() = GardenApi.config.skyMart
 
     var inInventory = false
 
+    private val COPPER_ITEM = SkyblockCurrency.COPPER.internalName
+
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
         if (!event.inventoryName.startsWith("SkyMart ")) return
 
@@ -54,47 +43,45 @@ object SkyMartCopperPrice {
             inInventory = true
             val table = mutableListOf<DisplayTableEntry>()
             for ((slot, item) in event.inventoryItems) {
-                val lore = item.getLore()
-                val otherItemsPrice = item.loreCosts().sumOf { it.getPrice() }.takeIf { it != -1.0 }
+                val costs = item.readLoreCosts()
+                val copper = costs.firstOrNull { it.internalName == COPPER_ITEM }?.amount
+                    ?: continue
+                val otherItemsPrice = costs
+                    .filter { it.internalName != COPPER_ITEM }
+                    .sumOf { it.internalName.getPrice() * it.amount }
+                    .takeIf { it != 0.0 }
 
-                for (line in lore) {
-                    val copper = copperPattern.matchMatcher(line) {
-                        group("amount").formatInt()
-                    } ?: continue
+                val internalName = item.getInternalName()
+                val itemPrice = internalName.getPriceOrNull(config.priceSource) ?: continue
+                val profit = itemPrice - (otherItemsPrice ?: 0.0)
 
-                    val internalName = item.getInternalName()
-                    val itemPrice = internalName.getPriceOrNull(config.priceSource) ?: continue
-                    val profit = itemPrice - (otherItemsPrice ?: 0.0)
+                val factor = profit / copper
+                val perFormat = factor.shortFormat()
 
-                    val factor = profit / copper
-                    val perFormat = factor.shortFormat()
-
-                    val itemName = item.repoItemName
-                    val hover = buildList {
-                        add(itemName)
-                        add("")
-                        add("§7Item price: §6${itemPrice.shortFormat()} ")
-                        otherItemsPrice?.let {
-                            add("§7Additional cost: §6${it.shortFormat()} ")
-                        }
-                        add("§7Profit per purchase: §6${profit.shortFormat()} ")
-                        add("")
-                        add("§7Copper amount: §c${copper.addSeparators()} ")
-                        add("§7Profit per copper: §6$perFormat ")
+                val itemName = item.repoItemName
+                val hover = buildList {
+                    add(itemName)
+                    add("")
+                    add("§7Item price: §6${itemPrice.shortFormat()} ")
+                    otherItemsPrice?.let {
+                        add("§7Additional cost: §6${it.shortFormat()} ")
                     }
-                    table.add(
-                        DisplayTableEntry(
-                            "$itemName§f:".asComponent(),
-                            "§6§l$perFormat".asComponent(),
-                            factor,
-                            internalName,
-                            hover.mapToComponents(),
-                            highlightsOnHoverSlots = listOf(slot),
-                        ),
-                    )
+                    add("§7Profit per purchase: §6${profit.shortFormat()} ")
+                    add("")
+                    add("§7Copper amount: §c${copper.addSeparators()} ")
+                    add("§7Profit per copper: §6$perFormat ")
                 }
+                table.add(
+                    DisplayTableEntry(
+                        "$itemName§f:".asComponent(),
+                        "§6§l$perFormat".asComponent(),
+                        factor,
+                        internalName,
+                        hover.mapToComponents(),
+                        highlightsOnHoverSlots = listOf(slot),
+                    ),
+                )
             }
-
             val newList = mutableListOf<Renderable>()
             newList.addString("§eCoins per Copper§f:")
             newList.add(RenderableUtils.fillTable(table, padding = 5, itemScale = config.itemScale))
@@ -103,12 +90,12 @@ object SkyMartCopperPrice {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
     }
 
     @HandleEvent
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (inInventory) {
             config.copperPricePos.renderRenderables(
                 display,
@@ -119,7 +106,7 @@ object SkyMartCopperPrice {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "garden.skyMartCopperPrice", "garden.skyMart.copperPrice")
         event.move(3, "garden.skyMartCopperPriceAdvancedStats", "garden.skyMart.copperPriceAdvancedStats")
         event.move(3, "garden.skyMartCopperPricePos", "garden.skyMart.copperPricePos")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.garden.pests
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -11,28 +9,24 @@ import at.hannibal2.skyhanni.utils.DisplayTableEntry
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LoreCostUtils
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
 object PesthunterProfit {
 
     private val config get() = GardenApi.config.pests.pesthunterShop
-    private val patternGroup = RepoPattern.group("garden.pests.pesthunter")
     private val DENY_LIST_ITEMS = listOf(
         "Close",
         "Pesthunter's Wares",
@@ -40,25 +34,17 @@ object PesthunterProfit {
     )
     private var display = emptyList<Renderable>()
     private var inInventory = false
-
-    /**
-     * REGEX-TEST: §2100 Pests
-     * REGEX-TEST: §21,500 Pests
-     */
-    private val pestCostPattern by patternGroup.pattern(
-        "garden.pests.pesthunter.cost",
-        "§2(?<pests>[\\d,]+) Pests",
-    )
+    private val PESTS_ITEM = SkyblockCurrency.PESTS.internalName
 
     fun isInInventory() = inInventory
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!config.profitEnabled) return
         if (event.inventoryName != "Pesthunter's Wares") return
 
@@ -78,7 +64,8 @@ object PesthunterProfit {
         } ?: return null
         if (slot == 49) return null
 
-        val totalCost = getFullCost(getRequiredItems(item)).takeIf { it >= 0 } ?: return null
+        val costs = item.readLoreCosts()
+        val totalCost = getFullCost(costs).takeIf { it >= 0 } ?: return null
         val nameString = itemName.formattedTextCompatLeadingWhiteLessResets()
         val (name, amount) = ItemUtils.readItemAmount(nameString) ?: return null
         val fixedDisplayName = name.replace("[Lvl 100]", "[Lvl {LVL}]")
@@ -88,7 +75,7 @@ object PesthunterProfit {
         val itemPrice = (internalName.getPrice() * amount).takeIf { it >= 0 } ?: return null
 
         val profit = itemPrice - totalCost
-        val pestsCost = getPestsCost(item)
+        val pestsCost = costs.firstOrNull { it.internalName == PESTS_ITEM }?.amount ?: 0L
         val profitPerPest = if (pestsCost > 0) profit / pestsCost else 0.0
         val color = if (profitPerPest > 0) "§6" else "§c"
 
@@ -111,28 +98,12 @@ object PesthunterProfit {
         )
     }
 
-    private fun getRequiredItems(item: SafeItemStack): List<String> {
-        val lore = item.getLore().filter { !pestCostPattern.matches(it) }
-
-        val startIndex = lore.indexOf("§7Cost") + 1
-        val endIndex = lore.indexOfFirstOrNull { it.isBlank() && lore.indexOf(it) > startIndex } ?: lore.size
-
-        return lore.subList(startIndex, endIndex).map { it.replace("§8 ", " §8") }
-    }
-
-    private fun getFullCost(requiredItems: List<String>): Double = requiredItems.mapNotNull {
-        ItemUtils.readItemAmount(it)
-    }.sumOf { (name, amount) ->
-        val internalName = NeuInternalName.fromItemNameOrNull(name) ?: return@sumOf 0.0
-        internalName.getPrice() * amount
-    }
-
-    private fun getPestsCost(item: SafeItemStack): Int = pestCostPattern.firstMatcher(item.getLore()) {
-        group("pests")?.formatDoubleOrNull()?.toInt() ?: 0
-    } ?: 0
+    private fun getFullCost(costs: List<LoreCostUtils.LoreCostEntry>): Double = costs
+        .filter { it.internalName != PESTS_ITEM }
+        .sumOf { it.internalName.getPrice() * it.amount }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (!inInventory) return
         config.profitPosition.renderRenderables(
             display,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -1,0 +1,165 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.LoreCostUtils
+import at.hannibal2.skyhanni.utils.LoreCostUtils.LoreCostEntry
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.SafeItemStack
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import net.minecraft.network.chat.Component
+
+@SkyHanniModule
+object NpcTradeHelper {
+
+    private val config get() = SkyHanniMod.feature.inventory.npcTrade
+
+    private const val TRADE_LINE = "§eClick to trade!"
+
+    private var tradeItems = mapOf<Int, TradeItem>()
+
+    /**
+     * [evaluable] is false when the owned amount is unknown, for example a currency SkyHanni
+     * does not track. Such an item is never marked as affordable.
+     */
+    private class CostLine(val rawLine: String, val text: String, val covered: Boolean, val evaluable: Boolean)
+
+    private class TradeItem(val lines: List<CostLine>, val headerSuffix: String) {
+        val canAfford = lines.all { it.evaluable && it.covered }
+    }
+
+    @HandleEvent
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+        updateItems(event.inventoryItems)
+    }
+
+    @HandleEvent
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        updateItems(event.inventoryItems)
+    }
+
+    @HandleEvent
+    private fun onInventoryClose() {
+        tradeItems = emptyMap()
+    }
+
+    private fun updateItems(inventoryItems: Map<Int, SafeItemStack>) {
+        if (!isEnabled()) {
+            tradeItems = emptyMap()
+            return
+        }
+        tradeItems = buildMap {
+            for ((slot, item) in inventoryItems) {
+                readTradeItem(item)?.let { put(slot, it) }
+            }
+        }
+    }
+
+    private fun readTradeItem(item: SafeItemStack): TradeItem? {
+        val lore = item.getLoreComponent().map { it.formattedTextCompatLessResets() }
+        if (TRADE_LINE !in lore) return null
+
+        val costs = lore.readLoreCosts(item.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        if (costs.isEmpty()) return null
+
+        var coinTotal = 0.0
+        val otherCosts = mutableListOf<String>()
+        val lines = costs.map { entry ->
+            val currency = SkyblockCurrency.getByInternalNameOrNull(entry.internalName)
+            if (currency != null && currency.coinValue == null) {
+                otherCosts.add(currency.formatAmount(entry.amount))
+            } else {
+                coinTotal += entry.internalName.getPrice() * entry.amount
+            }
+            buildCostLine(entry, currency)
+        }
+
+        val parts = buildList {
+            if (coinTotal > 0) add(coinTotal.formatCoin())
+            addAll(otherCosts)
+        }
+        val headerSuffix = if (parts.isEmpty()) "" else " §7(${parts.joinToString(" §7+ ")}§7)"
+        return TradeItem(lines, headerSuffix)
+    }
+
+    private fun buildCostLine(entry: LoreCostEntry, currency: SkyblockCurrency?): CostLine {
+        val internalName = entry.internalName
+        val amount = entry.amount
+
+        val owned = when {
+            internalName == NeuInternalName.MISSING_ITEM -> null
+            currency != null -> currency.getOwnedAmount()
+            else -> internalName.getAmountInInventory().toLong()
+        }
+        val covered = owned != null && owned >= amount
+
+        val suffix = when {
+            owned == null -> ""
+            covered -> " §a✔"
+            else -> " §8${owned.addSeparators()}§7/§8${amount.addSeparators()}"
+        }
+        val sacks = if (currency == null) internalName.getAmountInSacksOrNull() ?: 0 else 0
+        val sackText = if (sacks > 0) " §7(sacks: §a${sacks.addSeparators()}§7)" else ""
+
+        // currencies other than coins have no price, getPriceName would show a "(0)" behind them
+        val name = if (currency != null && currency.coinValue == null) {
+            currency.formatAmount(amount)
+        } else {
+            internalName.getPriceName(amount)
+        }
+
+        return CostLine(entry.rawLine, name + suffix + sackText, covered, owned != null)
+    }
+
+    @HandleEvent
+    private fun onToolTip(event: ToolTipTextEvent) {
+        if (!config.costBreakdown) return
+        val slot = event.slot?.index ?: return
+        val tradeItem = tradeItems[slot] ?: return
+
+        for ((index, component) in event.toolTip.withIndex()) {
+            val line = component.formattedTextCompatLessResets()
+            if (LoreCostUtils.isCostHeader(line)) {
+                // the inline form writes the only cost entry into the header line itself
+                val inlineCost = tradeItem.lines.firstOrNull { line.contains(it.rawLine) }
+                val newLine = inlineCost?.let { line.replace(it.rawLine, it.text) } ?: line
+                event.toolTip[index] = Component.literal(newLine + tradeItem.headerSuffix)
+                continue
+            }
+            val costLine = tradeItem.lines.firstOrNull { it.rawLine == line } ?: continue
+            event.toolTip[index] = Component.literal(costLine.text)
+        }
+    }
+
+    @HandleEvent
+    private fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!config.highlightAffordable || tradeItems.isEmpty()) return
+
+        for (slot in event.container.slots) {
+            val tradeItem = tradeItems[slot.index] ?: continue
+            if (tradeItem.canAfford) {
+                slot.highlight(LorenzColor.GREEN)
+            }
+        }
+    }
+
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && (config.highlightAffordable || config.costBreakdown)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.LoreCostUtils
 import at.hannibal2.skyhanni.utils.LoreCostUtils.LoreCostEntry
+import at.hannibal2.skyhanni.utils.LoreCostUtils.hasTradeLine
 import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
@@ -31,8 +32,6 @@ import net.minecraft.network.chat.Component
 object NpcTradeHelper {
 
     private val config get() = SkyHanniMod.feature.inventory.npcTrade
-
-    private const val TRADE_LINE = "§eClick to trade!"
 
     private var tradeItems = mapOf<Int, TradeItem>()
 
@@ -75,7 +74,7 @@ object NpcTradeHelper {
 
     private fun readTradeItem(item: SafeItemStack): TradeItem? {
         val lore = item.getLoreComponent().map { it.formattedTextCompatLessResets() }
-        if (TRADE_LINE !in lore) return null
+        if (!lore.hasTradeLine()) return null
 
         val costs = lore.readLoreCosts(item.hoverName.formattedTextCompatLeadingWhiteLessResets())
         if (costs.isEmpty()) return null

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -106,7 +106,7 @@ object NpcTradeHelper {
 
         val owned = when {
             internalName == NeuInternalName.MISSING_ITEM -> null
-            currency != null -> currency.getOwnedAmount()
+            currency != null -> currency.getOwnedAmountOrNull()
             else -> internalName.getAmountInInventory().toLong()
         }
         val covered = owned != null && owned >= amount

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -24,6 +24,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SkyblockCurrency
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import net.minecraft.network.chat.Component
@@ -39,7 +40,10 @@ object NpcTradeHelper {
      * [evaluable] is false when the owned amount is unknown, for example a currency SkyHanni
      * does not track. Such an item is never marked as affordable.
      */
-    private class CostLine(val rawLine: String, val text: String, val covered: Boolean, val evaluable: Boolean)
+    private class CostLine(val rawLine: String, val text: String, val covered: Boolean, val evaluable: Boolean) {
+        /** The tooltip adds color codes of its own to the lore line, so the lookup ignores them. */
+        val cleanLine = rawLine.removeColor()
+    }
 
     private class TradeItem(val lines: List<CostLine>, val headerSuffix: String) {
         val canAfford = lines.all { it.evaluable && it.covered }
@@ -144,7 +148,7 @@ object NpcTradeHelper {
                 event.toolTip[index] = Component.literal(newLine + tradeItem.headerSuffix)
                 continue
             }
-            val costLine = tradeItem.lines.firstOrNull { it.rawLine == line } ?: continue
+            val costLine = tradeItem.lines.firstOrNull { it.cleanLine == line.removeColor() } ?: continue
             event.toolTip[index] = Component.literal(costLine.text)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -135,7 +135,8 @@ object NpcTradeHelper {
         val tradeItem = tradeItems[slot] ?: return
 
         for ((index, component) in event.toolTip.withIndex()) {
-            val line = component.formattedTextCompatLessResets()
+            // the tooltip prefixes every lore line, the lines from the item itself do not have it
+            val line = component.formattedTextCompatLessResets().removePrefix("§5§o")
             if (LoreCostUtils.isCostHeader(line)) {
                 // the inline form writes the only cost entry into the header line itself
                 val inlineCost = tradeItem.lines.firstOrNull { line.contains(it.rawLine) }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
@@ -20,8 +20,8 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -29,13 +29,12 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
-import at.hannibal2.skyhanni.utils.UtilsPatterns
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -54,13 +53,6 @@ object CFApi {
     val patternGroup = RepoPattern.group("misc.chocolatefactory")
 
     // <editor-fold desc="Patterns">
-    /**
-     * REGEX-TEST: 46,559,892,200 Chocolate
-     */
-    val chocolateAmountPattern by patternGroup.pattern(
-        "chocolate.amount",
-        "(?<amount>[\\d,]+) Chocolate",
-    )
 
     /**
      * REGEX-TEST: Hoppity
@@ -141,8 +133,10 @@ object CFApi {
 
     private val partyModeRegex = Regex("§[a-fA-F0-9]")
 
+    val CHOCOLATE_ITEM = SkyblockCurrency.CHOCOLATE.internalName
+
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         DelayedRun.runNextTick {
             if (chocolateFactoryInventoryNamePattern.matches(event.inventoryName)) {
                 if (config.enabled) {
@@ -163,7 +157,7 @@ object CFApi {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<HoppityEggLocationsJson>("HoppityEggLocations")
 
         rabbitSlots = data.rabbitSlots
@@ -193,7 +187,7 @@ object CFApi {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val old = "event.chocolateFactory"
         val new = "inventory.chocolateFactory"
         event.move(44, "$old.enabled", "$new.enabled")
@@ -216,12 +210,8 @@ object CFApi {
         event.move(44, "$old.hoppityStatsPosition", "$new.hoppityStatsPosition")
     }
 
-    fun getChocolateBuyCost(lore: List<String>): Long? {
-        val nextLine = lore.nextAfter({ UtilsPatterns.costLinePattern.matches(it) }) ?: return null
-        return chocolateAmountPattern.matchMatcher(nextLine.removeColor()) {
-            group("amount").formatLong()
-        }
-    }
+    fun getChocolateBuyCost(lore: List<String>): Long? =
+        lore.readLoreCosts().firstOrNull { it.internalName == CHOCOLATE_ITEM }?.amount
 
     fun getNextLevelName(stack: SafeItemStack): String? = upgradeLorePattern.firstMatcher(stack.getLore()) {
         val isEmployee = stack.getLore().any { it == "§8Employee" }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
@@ -1,10 +1,7 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.ChocolateAmount
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -14,8 +11,8 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.loreCosts
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
@@ -74,14 +71,14 @@ object CFShopPrice {
     private var chocolateSpent = 0L
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed() {
         if (inInventory) {
             update()
         }
     }
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
         val isInShop = menuNamePattern.matches(event.inventoryName)
         val isInShopOptions = UtilsPatterns.shopOptionsPattern.matches(event.inventoryName)
@@ -115,7 +112,10 @@ object CFShopPrice {
             val chocolate = CFApi.getChocolateBuyCost(lore) ?: continue
             val internalName = item.getInternalName()
             val itemPrice = internalName.getPriceOrNull() ?: continue
-            val otherItemsPrice = item.loreCosts().sumOf { it.getPrice() }.takeIf { it != 0.0 }
+            val otherItemsPrice = item.readLoreCosts()
+                .filter { it.internalName != CFApi.CHOCOLATE_ITEM }
+                .sumOf { it.internalName.getPrice() * it.amount }
+                .takeIf { it != 0.0 }
             val canBeBought = lore.any { it == "§eClick to trade!" }
 
             newProducts.add(Product(slot, item.repoItemName, internalName, chocolate, itemPrice, otherItemsPrice, canBeBought))
@@ -181,13 +181,13 @@ object CFShopPrice {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
         callUpdate = false
     }
 
     @HandleEvent
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    private fun onChestGuiRender() {
         if (inInventory) {
             config.position.renderRenderables(
                 display,
@@ -198,7 +198,7 @@ object CFShopPrice {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!inInventory) return
         itemBoughtPattern.matchMatcher(event.message) {
             val item = group("item")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LoreCostUtils.hasTradeLine
 import at.hannibal2.skyhanni.utils.LoreCostUtils.readLoreCosts
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -116,7 +117,7 @@ object CFShopPrice {
                 .filter { it.internalName != CFApi.CHOCOLATE_ITEM }
                 .sumOf { it.internalName.getPrice() * it.amount }
                 .takeIf { it != 0.0 }
-            val canBeBought = lore.any { it == "§eClick to trade!" }
+            val canBeBought = lore.hasTradeLine()
 
             newProducts.add(Product(slot, item.repoItemName, internalName, chocolate, itemPrice, otherItemsPrice, canBeBought))
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
@@ -327,8 +328,8 @@ object CFDataLoader {
     private fun processChocolateItem(item: SafeItemStack) {
         val profileStorage = profileStorage ?: return
 
-        CFApi.chocolateAmountPattern.matchMatcher(item.cleanName) {
-            profileStorage.currentChocolate = group("amount").formatLong()
+        SkyblockCurrency.CHOCOLATE.readAmountOrNull(item.cleanName)?.let {
+            profileStorage.currentChocolate = it
         }
         for (line in item.getLore()) {
             chocolatePerSecondPattern.matchMatcher(line) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -42,7 +42,7 @@ object ItemPriceUtils {
         priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY,
         pastRecipes: List<PrimitiveRecipe> = emptyList(),
     ): Double? {
-        SkyblockCurrency.getByInternalNameOrNull(this)?.let { return it.coinValue }
+        SkyblockCurrency.getByInternalNameOrNull(this)?.coinValue?.let { return it }
 
         when (this) {
             NeuInternalName.GEMSTONE_COLLECTION -> return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -42,8 +42,9 @@ object ItemPriceUtils {
         priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY,
         pastRecipes: List<PrimitiveRecipe> = emptyList(),
     ): Double? {
+        SkyblockCurrency.getByInternalNameOrNull(this)?.let { return it.coinValue }
+
         when (this) {
-            SKYBLOCK_COIN -> return 1.0
             NeuInternalName.GEMSTONE_COLLECTION -> return 0.0
             NeuInternalName.JASPER_CRYSTAL -> return 0.0
             NeuInternalName.RUBY_CRYSTAL -> return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -766,7 +766,7 @@ object ItemUtils {
         if (this == NeuInternalName.WISP_POTION) {
             return "§fWisp's Ice-Flavored Water"
         }
-        SkyblockCurrency.getByInternalNameOrNull(this)?.let { return it.displayName }
+        SkyblockCurrency.getByInternalNameOrNull(this)?.let { return it.coloredName }
         if (this == NeuInternalName.NONE) {
             error("NEUInternalName.NONE has no name!")
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -766,9 +766,7 @@ object ItemUtils {
         if (this == NeuInternalName.WISP_POTION) {
             return "§fWisp's Ice-Flavored Water"
         }
-        if (this == NeuInternalName.SKYBLOCK_COIN) {
-            return "§6Coins"
-        }
+        SkyblockCurrency.getByInternalNameOrNull(this)?.let { return it.displayName }
         if (this == NeuInternalName.NONE) {
             error("NEUInternalName.NONE has no name!")
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -161,7 +161,7 @@ object ItemUtils {
     fun NeuInternalName.getRawBaseStats(): Map<String, Int> = itemBaseStatsRaw[this].orEmpty()
 
     @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         ConditionalUtils.onToggle(SkyHanniMod.feature.misc.replaceRomanNumerals) {
             itemNameCache.clear()
             compactItemNameCache.clear()
@@ -409,7 +409,7 @@ object ItemUtils {
 
         private val value = StableOrTransientValue(1.seconds) {
             val texture = SkullTextureHolder.getTexture(repoSkullId)
-            val stack = ItemUtils.createSkull(
+            val stack = createSkull(
                 displayName,
                 uuid,
                 texture ?: SkullTextureHolder.getTextureOrFallback(repoSkullId),
@@ -699,7 +699,7 @@ object ItemUtils {
     )
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         compactItemNameCache.clear()
         repoSkullProviders.forEach { it.reset() }
         coinSkullCache.clear()
@@ -710,7 +710,7 @@ object ItemUtils {
     }
 
     @HandleEvent
-    fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+    private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
         bazaarOverrides = event.getConstant<List<BazaarOverride>>("bazaarstocks").associate {
             it.bazaarInternalName to it.neuInternalName
         }
@@ -830,25 +830,6 @@ object ItemUtils {
         }
     }
 
-    fun SafeItemStack.loreCosts(): MutableList<NeuInternalName> {
-        var found = false
-        val list = mutableListOf<NeuInternalName>()
-        for (lines in getLore()) {
-            if (lines == "§7Cost") {
-                found = true
-                continue
-            }
-
-            if (!found) continue
-            if (lines.isEmpty()) return list
-
-            NeuInternalName.fromItemNameOrNull(lines)?.let {
-                list.add(it)
-            }
-        }
-        return list
-    }
-
     fun neededItems(recipe: PrimitiveRecipe): Map<NeuInternalName, Int> {
         val neededItems = mutableMapOf<NeuInternalName, Int>()
         for ((material, amount) in recipe.ingredients.toPrimitiveItemStacks()) {
@@ -865,7 +846,7 @@ object ItemUtils {
     }.sum()
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestitem") {
             description = "test item internal name resolving"
             category = CommandCategory.DEVELOPER_TEST
@@ -967,7 +948,7 @@ object ItemUtils {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Missing Repo Items")
 
         if (missingRepoItems.isNotEmpty()) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -3,10 +3,10 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
-import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
@@ -32,51 +32,51 @@ object LoreCostUtils {
         "(?:§5§o)?§7Cost(?:: (?<inline>.+))?",
     )
 
-    /**
-     * REGEX-TEST: §b5,000 Bits
-     * REGEX-TEST: §240 Pests
-     * REGEX-TEST: §63,000,000,000 Chocolate
-     * REGEX-TEST: §c250 Copper
-     * REGEX-TEST: §61,940,000 Coins
-     */
-    private val currencyPattern by patternGroup.pattern(
-        "currency",
-        "(?:§.)*(?<amount>[\\d,]+) (?<name>[\\w' ]+)",
-    )
+    fun SafeItemStack.readLoreCosts(): List<LoreCostEntry> = getLoreComponent()
+        .map { it.formattedTextCompatLessResets() }
+        .readLoreCosts(hoverName.formattedTextCompatLeadingWhiteLessResets())
 
-    fun SafeItemStack.readLoreCosts(): List<LoreCostEntry> =
-        getLoreComponent().map { it.formattedTextCompatLessResets() }.readLoreCosts()
-
-    fun List<String>.readLoreCosts(): List<LoreCostEntry> {
-        val headerIndex = indexOfFirst { costHeaderPattern.matches(it) }.takeIf { it != -1 } ?: return emptyList()
+    fun List<String>.readLoreCosts(itemName: String = "<unknown>"): List<LoreCostEntry> {
+        val headerIndex = indexOfLast { costHeaderPattern.matches(it) }.takeIf { it != -1 } ?: return emptyList()
 
         costHeaderPattern.matchMatcher(this[headerIndex]) {
-            groupOrNull("inline")?.let { return listOf(readCostLine(it)) }
+            groupOrNull("inline")?.let { return listOf(readCostLine(it, itemName)) }
         }
 
-        return drop(headerIndex + 1).takeWhile { it.isNotEmpty() }.map { readCostLine(it) }
+        return drop(headerIndex + 1).takeWhile { it.isNotEmpty() }.map { readCostLine(it, itemName) }
     }
 
-    private fun readCostLine(rawLine: String): LoreCostEntry {
+    private fun readCostLine(rawLine: String, itemName: String): LoreCostEntry {
         // some lines write the amount as "Gold medal§8 x2" instead of "Gold medal §8x2"
         val line = rawLine.replace("§8 ", " §8")
 
         readCurrencyOrNull(line)?.let { return it }
 
         val (name, amount) = ItemUtils.readItemAmount(line) ?: run {
-            ErrorManager.logErrorStateWithData(
-                "Could not read a cost line",
-                "readItemAmount failed on a lore cost line",
-                "rawLine" to rawLine,
-                betaOnly = true,
-            )
+            logCostLineError("Could not read the amount of a cost line", rawLine, itemName)
             return LoreCostEntry(NeuInternalName.MISSING_ITEM, 1)
         }
-        return LoreCostEntry(NeuInternalName.fromItemName(name), amount.toLong())
+
+        val internalName = NeuInternalName.fromItemNameOrNull(name) ?: run {
+            logCostLineError("Unknown item in a cost line", rawLine, itemName)
+            NeuInternalName.MISSING_ITEM
+        }
+        return LoreCostEntry(internalName, amount.toLong())
     }
 
-    private fun readCurrencyOrNull(line: String): LoreCostEntry? = currencyPattern.matchMatcher(line) {
-        val currency = SkyblockCurrency.getByLoreNameOrNull(group("name")) ?: return@matchMatcher null
-        LoreCostEntry(currency.internalName, group("amount").formatLong())
+    private fun logCostLineError(reason: String, rawLine: String, itemName: String) {
+        ErrorManager.logErrorStateWithData(
+            "Could not read the cost of an item",
+            reason,
+            "rawLine" to rawLine,
+            "itemName" to itemName,
+            "inventoryName" to InventoryUtils.openInventoryName(),
+            betaOnly = true,
+        )
     }
+
+    private fun readCurrencyOrNull(line: String): LoreCostEntry? =
+        SkyblockCurrency.readCurrencyOrNull(line)?.let { (currency, amount) ->
+            LoreCostEntry(currency.internalName, amount)
+        }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -1,0 +1,82 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object LoreCostUtils {
+
+    /**
+     * One line of an item cost lore.
+     *
+     * [internalName] is [NeuInternalName.MISSING_ITEM] when the line could not be read.
+     */
+    data class LoreCostEntry(val internalName: NeuInternalName, val amount: Long)
+
+    private val patternGroup = RepoPattern.group("utils.lore.cost")
+
+    /**
+     * REGEX-TEST: §7Cost
+     * REGEX-TEST: §5§o§7Cost
+     * REGEX-TEST: §7Cost: §b5,000 Bits
+     */
+    private val costHeaderPattern by patternGroup.pattern(
+        "header",
+        "(?:§5§o)?§7Cost(?:: (?<inline>.+))?",
+    )
+
+    /**
+     * REGEX-TEST: §b5,000 Bits
+     * REGEX-TEST: §240 Pests
+     * REGEX-TEST: §63,000,000,000 Chocolate
+     * REGEX-TEST: §c250 Copper
+     * REGEX-TEST: §61,940,000 Coins
+     */
+    private val currencyPattern by patternGroup.pattern(
+        "currency",
+        "(?:§.)*(?<amount>[\\d,]+) (?<name>[\\w' ]+)",
+    )
+
+    fun SafeItemStack.readLoreCosts(): List<LoreCostEntry> =
+        getLoreComponent().map { it.formattedTextCompatLessResets() }.readLoreCosts()
+
+    fun List<String>.readLoreCosts(): List<LoreCostEntry> {
+        val headerIndex = indexOfFirst { costHeaderPattern.matches(it) }.takeIf { it != -1 } ?: return emptyList()
+
+        costHeaderPattern.matchMatcher(this[headerIndex]) {
+            groupOrNull("inline")?.let { return listOf(readCostLine(it)) }
+        }
+
+        return drop(headerIndex + 1).takeWhile { it.isNotEmpty() }.map { readCostLine(it) }
+    }
+
+    private fun readCostLine(rawLine: String): LoreCostEntry {
+        // some lines write the amount as "Gold medal§8 x2" instead of "Gold medal §8x2"
+        val line = rawLine.replace("§8 ", " §8")
+
+        readCurrencyOrNull(line)?.let { return it }
+
+        val (name, amount) = ItemUtils.readItemAmount(line) ?: run {
+            ErrorManager.logErrorStateWithData(
+                "Could not read a cost line",
+                "readItemAmount failed on a lore cost line",
+                "rawLine" to rawLine,
+                betaOnly = true,
+            )
+            return LoreCostEntry(NeuInternalName.MISSING_ITEM, 1)
+        }
+        return LoreCostEntry(NeuInternalName.fromItemName(name), amount.toLong())
+    }
+
+    private fun readCurrencyOrNull(line: String): LoreCostEntry? = currencyPattern.matchMatcher(line) {
+        val currency = SkyblockCurrency.getByLoreNameOrNull(group("name")) ?: return@matchMatcher null
+        LoreCostEntry(currency.internalName, group("amount").formatLong())
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -23,16 +24,31 @@ object LoreCostUtils {
 
     fun isCostHeader(line: String): Boolean = costHeaderPattern.matches(line)
 
-    private val patternGroup = RepoPattern.group("utils.lore.cost")
+    /** True when the item can be bought right now, as opposed to a locked or already owned entry. */
+    fun List<String>.hasTradeLine(): Boolean = any { tradeLinePattern.matches(it.removeColor()) }
+
+    private val patternGroup = RepoPattern.group("utils.lore")
 
     /**
+     * This is one of the few patterns that keeps its color codes on purpose. The cost written
+     * into the header line is handed on as is, so that features can find that exact line again
+     * in the tooltip. Matching without color would strip it and break that lookup.
+     *
      * REGEX-TEST: §7Cost
      * REGEX-TEST: §5§o§7Cost
      * REGEX-TEST: §7Cost: §b5,000 Bits
      */
     private val costHeaderPattern by patternGroup.pattern(
-        "header",
-        "(?:§5§o)?§7Cost(?:: (?<inline>.+))?",
+        "cost.header",
+        "(?:§.)*Cost(?:: (?<cost>.+))?",
+    )
+
+    /**
+     * REGEX-TEST: Click to trade!
+     */
+    private val tradeLinePattern by patternGroup.pattern(
+        "trade.click",
+        "Click to trade!",
     )
 
     fun SafeItemStack.readLoreCosts(): List<LoreCostEntry> = getLoreComponent()
@@ -43,7 +59,7 @@ object LoreCostUtils {
         val headerIndex = indexOfLast { costHeaderPattern.matches(it) }.takeIf { it != -1 } ?: return emptyList()
 
         costHeaderPattern.matchMatcher(this[headerIndex]) {
-            groupOrNull("inline")?.let { return listOf(readCostLine(it, itemName)) }
+            groupOrNull("cost")?.let { return listOf(readCostLine(it, itemName)) }
         }
 
         return drop(headerIndex + 1).takeWhile { it.isNotEmpty() }.map { readCostLine(it, itemName) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -17,8 +17,11 @@ object LoreCostUtils {
      * One line of an item cost lore.
      *
      * [internalName] is [NeuInternalName.MISSING_ITEM] when the line could not be read.
+     * [rawLine] is the lore line this entry was read from, unchanged.
      */
-    data class LoreCostEntry(val internalName: NeuInternalName, val amount: Long)
+    data class LoreCostEntry(val internalName: NeuInternalName, val amount: Long, val rawLine: String)
+
+    fun isCostHeader(line: String): Boolean = costHeaderPattern.matches(line)
 
     private val patternGroup = RepoPattern.group("utils.lore.cost")
 
@@ -50,18 +53,18 @@ object LoreCostUtils {
         // some lines write the amount as "Gold medal§8 x2" instead of "Gold medal §8x2"
         val line = rawLine.replace("§8 ", " §8")
 
-        readCurrencyOrNull(line)?.let { return it }
+        readCurrencyOrNull(line, rawLine)?.let { return it }
 
         val (name, amount) = ItemUtils.readItemAmount(line) ?: run {
             logCostLineError("Could not read the amount of a cost line", rawLine, itemName)
-            return LoreCostEntry(NeuInternalName.MISSING_ITEM, 1)
+            return LoreCostEntry(NeuInternalName.MISSING_ITEM, 1, rawLine)
         }
 
         val internalName = NeuInternalName.fromItemNameOrNull(name) ?: run {
             logCostLineError("Unknown item in a cost line", rawLine, itemName)
             NeuInternalName.MISSING_ITEM
         }
-        return LoreCostEntry(internalName, amount.toLong())
+        return LoreCostEntry(internalName, amount.toLong(), rawLine)
     }
 
     private fun logCostLineError(reason: String, rawLine: String, itemName: String) {
@@ -75,8 +78,8 @@ object LoreCostUtils {
         )
     }
 
-    private fun readCurrencyOrNull(line: String): LoreCostEntry? =
+    private fun readCurrencyOrNull(line: String, rawLine: String): LoreCostEntry? =
         SkyblockCurrency.readCurrencyOrNull(line)?.let { (currency, amount) ->
-            LoreCostEntry(currency.internalName, amount)
+            LoreCostEntry(currency.internalName, amount, rawLine)
         }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -69,6 +69,11 @@ value class NeuInternalName private constructor(private val internalName: String
 
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".toInternalName()
 
+        val SKYBLOCK_GOLD_MEDAL = "SKYBLOCK_GOLD_MEDAL".toInternalName()
+        val SKYBLOCK_SILVER_MEDAL = "SKYBLOCK_SILVER_MEDAL".toInternalName()
+        val SKYBLOCK_BRONZE_MEDAL = "SKYBLOCK_BRONZE_MEDAL".toInternalName()
+        val SKYBLOCK_COPPER = "SKYBLOCK_COPPER".toInternalName()
+
         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -26,7 +26,7 @@ value class NeuInternalName private constructor(private val internalName: String
     fun replace(oldValue: String, newValue: String): NeuInternalName =
         internalName.replace(oldValue, newValue, ignoreCase = true).toInternalName()
 
-    fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
+    fun isKnownItem(): Boolean = getItemStackOrNull() != null || SkyblockCurrency.getByInternalNameOrNull(this) != null
 
     fun isArmor(): Boolean = internalName.endsWith("_BOOTS") ||
         internalName.endsWith("_HELMET") ||
@@ -66,7 +66,9 @@ value class NeuInternalName private constructor(private val internalName: String
         val GEMSTONE_COLLECTION = "GEMSTONE_COLLECTION".toInternalName()
         val JASPER_CRYSTAL = "JASPER_CRYSTAL".toInternalName()
         val RUBY_CRYSTAL = "RUBY_CRYSTAL".toInternalName()
+
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".toInternalName()
+
         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()
@@ -92,7 +94,8 @@ value class NeuInternalName private constructor(private val internalName: String
         }
 
         fun fromItemNameOrNull(itemName: String): NeuInternalName? = itemNameCache.getOrPut(itemName) {
-            ItemNameResolver.getInternalNameOrNull(itemName.removeSuffix(" Pet")) ?: getCoins(itemName)
+            ItemNameResolver.getInternalNameOrNull(itemName.removeSuffix(" Pet"))
+                ?: SkyblockCurrency.getByLoreNameOrNull(itemName)?.internalName
         }
 
         fun fromItemNameOrInternalName(itemName: String): NeuInternalName = fromItemNameOrNull(itemName) ?: itemName.toInternalName()
@@ -100,19 +103,6 @@ value class NeuInternalName private constructor(private val internalName: String
         private val categoryCache = TimeLimitedCache<NeuInternalName, ItemCategory>(10.minutes)
 
         private val petCache: TimeLimitedCache<NeuInternalName, Boolean> = TimeLimitedCache(10.minutes)
-
-        private fun getCoins(itemName: String): NeuInternalName? = when {
-            isCoins(itemName) -> SKYBLOCK_COIN
-            else -> null
-        }
-
-        private val coinNames = setOf(
-            "coin", "coins",
-            "skyblock coin", "skyblock coins",
-            "skyblock_coin", "skyblock_coins",
-        )
-
-        private fun isCoins(itemName: String): Boolean = itemName.lowercase() in coinNames
 
         fun fromItemName(itemName: String): NeuInternalName = fromItemNameOrNull(itemName) ?: run {
             val name = "itemName:$itemName"

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -24,12 +24,14 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
  *
  * [internalName] has to be the id of the real repo item whenever the name resolves to one, even
  * if that item has no price, as is the case for [NeuInternalName.SKYBLOCK_COPPER].
+ * [displayName] is written without color, use [coloredName] where the color is wanted.
  * [coinValue] is the worth of a single unit in coins, or null when unknown.
  * [loreNames] are the names as written in the lore, lowercase and without color codes.
  */
 enum class SkyblockCurrency(
     val internalName: NeuInternalName,
     val displayName: String,
+    val color: LorenzColor,
     val coinValue: Double? = null,
     private val loreNames: Set<String>,
     /** How much of this currency the player owns, or null when SkyHanni does not track it. */
@@ -38,18 +40,19 @@ enum class SkyblockCurrency(
     // Universal
     COINS(
         NeuInternalName.SKYBLOCK_COIN,
-        "§6Coins",
+        "Coins",
+        GOLD,
         coinValue = 1.0,
         loreNames = setOf("coin", "coins", "skyblock coin", "skyblock coins", "skyblock_coin", "skyblock_coins"),
         ownedAmount = { PurseApi.currentPurse.toLong() },
     ),
 
     // Bits Shop from Elisabeth
-    BITS("BITS".toInternalName(), "§bBits", loreNames = setOf("bit", "bits"), ownedAmount = { BitsApi.bits.toLong() }),
+    BITS("BITS".toInternalName(), "Bits", AQUA, loreNames = setOf("bit", "bits"), ownedAmount = { BitsApi.bits.toLong() }),
 
     // Pesthunter's Wares in Garden
     PESTS(
-        "PESTS".toInternalName(), "§2Pests", loreNames = setOf("pest", "pests"),
+        "PESTS".toInternalName(), "Pests", DARK_GREEN, loreNames = setOf("pest", "pests"),
         // TODO add
         ownedAmount = { null },
     ),
@@ -57,49 +60,52 @@ enum class SkyblockCurrency(
     // Chocolate Factory
     CHOCOLATE(
         "CHOCOLATE".toInternalName(),
-        "§6Chocolate",
+        "Chocolate",
+        GOLD,
         loreNames = setOf("chocolate"),
         ownedAmount = { ChocolateAmount.CURRENT.chocolate() + ChocolateAmount.chocolateSinceUpdate() },
     ),
 
     // SkyMart in Garden
     COPPER(
-        NeuInternalName.SKYBLOCK_COPPER, "§cCopper", loreNames = setOf("copper"),
+        NeuInternalName.SKYBLOCK_COPPER, "Copper", RED, loreNames = setOf("copper"),
         // TODO add
         ownedAmount = { null },
     ),
 
     // Anita in Garden
     GOLD_MEDAL(
-        NeuInternalName.SKYBLOCK_GOLD_MEDAL, "§6Gold medal", loreNames = setOf("gold medal", "gold medals"),
+        NeuInternalName.SKYBLOCK_GOLD_MEDAL, "Gold medal", GOLD, loreNames = setOf("gold medal", "gold medals"),
         // TODO add
         ownedAmount = { null },
     ),
     SILVER_MEDAL(
-        NeuInternalName.SKYBLOCK_SILVER_MEDAL, "§fSilver medal", loreNames = setOf("silver medal", "silver medals"),
+        NeuInternalName.SKYBLOCK_SILVER_MEDAL, "Silver medal", WHITE, loreNames = setOf("silver medal", "silver medals"),
         // TODO add
         ownedAmount = { null },
     ),
     BRONZE_MEDAL(
-        NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals"),
+        NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "Bronze medal", RED, loreNames = setOf("bronze medal", "bronze medals"),
         // TODO add
         ownedAmount = { null },
     ),
 
     // Tony's Shop in the Farming Islands
     PELTS(
-        "PELTS".toInternalName(), "§5Pelts", loreNames = setOf("pelt", "pelts"),
+        "PELTS".toInternalName(), "Pelts", DARK_PURPLE, loreNames = setOf("pelt", "pelts"),
         // TODO add
         ownedAmount = { null },
     ),
 
     // Cosmetics in various shops
     GEMS(
-        "GEMS".toInternalName(), "§aGems", loreNames = setOf("gem", "gems"),
+        "GEMS".toInternalName(), "Gems", GREEN, loreNames = setOf("gem", "gems"),
         // TODO add
         ownedAmount = { null },
     ),
     ;
+
+    val coloredName: String = color.getChatColor() + displayName
 
     /**
      * Reads the amount from a text that writes it in front of the name, like "5,000 Bits".
@@ -110,27 +116,27 @@ enum class SkyblockCurrency(
     fun getOwnedAmountOrNull(): Long? = ownedAmount.invoke()
 
     /** Formats an amount the way it appears in a cost lore, for example "§b5,000 Bits". */
-    fun formatAmount(amount: Long): String = displayName.take(2) + amount.addSeparators() + " " + displayName.removeColor()
+    fun formatAmount(amount: Long): String = "${color.getChatColor()}${amount.addSeparators()} $displayName"
 
     @SkyHanniModule
     companion object {
 
         /**
-         * REGEX-TEST: §b5,000 Bits
-         * REGEX-TEST: §240 Pests
-         * REGEX-TEST: §c250 Copper
-         * REGEX-TEST: §61,940,000 Coins
-         * REGEX-TEST: §629.1 Coins
+         * REGEX-TEST: 5,000 Bits
+         * REGEX-TEST: 40 Pests
+         * REGEX-TEST: 250 Copper
+         * REGEX-TEST: 1,940,000 Coins
+         * REGEX-TEST: 29.1 Coins
          * REGEX-TEST: 46,559,892,200 Chocolate
-         * REGEX-TEST: §a400 Gems
-         * REGEX-TEST: §575 Pelts
+         * REGEX-TEST: 400 Gems
+         * REGEX-TEST: 75 Pelts
          */
         private val amountPattern by RepoPattern.pattern(
             "utils.currency.amount",
-            "(?:§.)*(?<amount>[\\d,.]+) (?<name>[\\w' ]+)",
+            "(?<amount>[\\d,.]+) (?<name>[\\w' ]+)",
         )
 
-        fun readCurrencyOrNull(text: String): Pair<SkyblockCurrency, Long>? = amountPattern.matchMatcher(text) {
+        fun readCurrencyOrNull(text: String): Pair<SkyblockCurrency, Long>? = amountPattern.matchMatcher(text.removeColor()) {
             val currency = getByLoreNameOrNull(group("name")) ?: return@matchMatcher null
             currency to group("amount").formatLong()
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -37,7 +37,7 @@ enum class SkyblockCurrency(
         loreNames = setOf("coin", "coins", "skyblock coin", "skyblock coins", "skyblock_coin", "skyblock_coins"),
     ),
 
-    // Bits Shop from Elisabeth
+    // Bits Shop from Elizabeth
     BITS("BITS".toInternalName(), "§bBits", loreNames = setOf("bit", "bits")),
 
     // Pesthunter's Wares in Garden

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -32,8 +32,8 @@ enum class SkyblockCurrency(
     val displayName: String,
     val coinValue: Double? = null,
     private val loreNames: Set<String>,
-    /** How much of this currency the player owns, or 0 when SkyHanni does not track it. */
-    private val ownedAmount: (() -> Long),
+    /** How much of this currency the player owns, or null when SkyHanni does not track it. */
+    private val ownedAmount: (() -> Long?),
 ) {
     // Universal
     COINS(
@@ -51,7 +51,7 @@ enum class SkyblockCurrency(
     PESTS(
         "PESTS".toInternalName(), "§2Pests", loreNames = setOf("pest", "pests"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
 
     // Chocolate Factory
@@ -66,38 +66,38 @@ enum class SkyblockCurrency(
     COPPER(
         NeuInternalName.SKYBLOCK_COPPER, "§cCopper", loreNames = setOf("copper"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
 
     // Anita in Garden
     GOLD_MEDAL(
         NeuInternalName.SKYBLOCK_GOLD_MEDAL, "§6Gold medal", loreNames = setOf("gold medal", "gold medals"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
     SILVER_MEDAL(
         NeuInternalName.SKYBLOCK_SILVER_MEDAL, "§fSilver medal", loreNames = setOf("silver medal", "silver medals"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
     BRONZE_MEDAL(
         NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
 
     // Tony's Shop in the Farming Islands
     PELTS(
         "PELTS".toInternalName(), "§5Pelts", loreNames = setOf("pelt", "pelts"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
 
     // Cosmetics in various shops
     GEMS(
         "GEMS".toInternalName(), "§aGems", loreNames = setOf("gem", "gems"),
         // TODO add
-        ownedAmount = { 0 },
+        ownedAmount = { null },
     ),
     ;
 
@@ -107,7 +107,7 @@ enum class SkyblockCurrency(
      */
     fun readAmountOrNull(text: String): Long? = readCurrencyOrNull(text)?.takeIf { it.first == this }?.second
 
-    fun getOwnedAmount(): Long = ownedAmount.invoke()
+    fun getOwnedAmountOrNull(): Long? = ownedAmount.invoke()
 
     /** Formats an amount the way it appears in a cost lore, for example "§b5,000 Bits". */
     fun formatAmount(amount: Long): String = displayName.take(2) + amount.addSeparators() + " " + displayName.removeColor()

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -120,13 +120,14 @@ enum class SkyblockCurrency(
          * REGEX-TEST: §240 Pests
          * REGEX-TEST: §c250 Copper
          * REGEX-TEST: §61,940,000 Coins
+         * REGEX-TEST: §629.1 Coins
          * REGEX-TEST: 46,559,892,200 Chocolate
          * REGEX-TEST: §a400 Gems
          * REGEX-TEST: §575 Pelts
          */
         private val amountPattern by RepoPattern.pattern(
             "utils.currency.amount",
-            "(?:§.)*(?<amount>[\\d,]+) (?<name>[\\w' ]+)",
+            "(?:§.)*(?<amount>[\\d,.]+) (?<name>[\\w' ]+)",
         )
 
         fun readCurrencyOrNull(text: String): Pair<SkyblockCurrency, Long>? = amountPattern.matchMatcher(text) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -1,16 +1,25 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 /**
- * Currencies that can appear in an item cost lore, but are not real items in the NEU repo.
+ * Currencies that can appear in an item cost lore.
  *
+ * Entries written as an amount followed by the name, like "5,000 Bits", need this enum to be
+ * read at all, since [ItemUtils.readItemAmount] cannot separate the amount from the name there.
+ * Entries with the amount behind the name, like "Gold medal §8x2", are already read by the
+ * regular item path and are listed here only so that features can refer to them.
+ *
+ * [internalName] has to be the id of the real repo item whenever the name resolves to one, even
+ * if that item has no price, as is the case for [NeuInternalName.SKYBLOCK_COPPER].
  * [coinValue] is the worth of a single unit in coins, or null when unknown.
  * [loreNames] are the names as written in the lore, lowercase and without color codes.
  */
@@ -37,15 +46,48 @@ enum class SkyblockCurrency(
     // Chocolate Factory
     CHOCOLATE("CHOCOLATE".toInternalName(), "§6Chocolate", loreNames = setOf("chocolate")),
 
-    // Anita and SkyMart in Garden
-    COPPER("COPPER".toInternalName(), "§cCopper", loreNames = setOf("copper")),
-    GOLD_MEDAL("GOLD_MEDAL".toInternalName(), "§6Gold medal", loreNames = setOf("gold medal", "gold medals")),
-    SILVER_MEDAL("SILVER_MEDAL".toInternalName(), "§fSilver medal", loreNames = setOf("silver medal", "silver medals")),
-    BRONZE_MEDAL("BRONZE_MEDAL".toInternalName(), "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals")),
+    // SkyMart in Garden
+    COPPER(NeuInternalName.SKYBLOCK_COPPER, "§cCopper", loreNames = setOf("copper")),
+
+    // Anita in Garden
+    GOLD_MEDAL(NeuInternalName.SKYBLOCK_GOLD_MEDAL, "§6Gold medal", loreNames = setOf("gold medal", "gold medals")),
+    SILVER_MEDAL(NeuInternalName.SKYBLOCK_SILVER_MEDAL, "§fSilver medal", loreNames = setOf("silver medal", "silver medals")),
+    BRONZE_MEDAL(NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals")),
+
+    // Tony's Shop in the Farming Islands
+    PELTS("PELTS".toInternalName(), "§5Pelts", loreNames = setOf("pelt", "pelts")),
+
+    // Cosmetics in various shops
+    GEMS("GEMS".toInternalName(), "§aGems", loreNames = setOf("gem", "gems")),
     ;
+
+    /**
+     * Reads the amount from a text that writes it in front of the name, like "5,000 Bits".
+     * Returns null for currencies written the other way around, like "Gold medal §8x2".
+     */
+    fun readAmountOrNull(text: String): Long? = readCurrencyOrNull(text)?.takeIf { it.first == this }?.second
 
     @SkyHanniModule
     companion object {
+
+        /**
+         * REGEX-TEST: §b5,000 Bits
+         * REGEX-TEST: §240 Pests
+         * REGEX-TEST: §c250 Copper
+         * REGEX-TEST: §61,940,000 Coins
+         * REGEX-TEST: 46,559,892,200 Chocolate
+         * REGEX-TEST: §a400 Gems
+         * REGEX-TEST: §575 Pelts
+         */
+        private val amountPattern by RepoPattern.pattern(
+            "utils.currency.amount",
+            "(?:§.)*(?<amount>[\\d,]+) (?<name>[\\w' ]+)",
+        )
+
+        fun readCurrencyOrNull(text: String): Pair<SkyblockCurrency, Long>? = amountPattern.matchMatcher(text) {
+            val currency = getByLoreNameOrNull(group("name")) ?: return@matchMatcher null
+            currency to group("amount").formatLong()
+        }
 
         private val byInternalName by lazy { entries.associateBy { it.internalName } }
 
@@ -57,19 +99,33 @@ enum class SkyblockCurrency(
         }
 
         /**
-         * A currency id that is also a real repo item would lose its price,
-         * since [ItemPriceUtils.getPriceOrNull] answers from this enum first.
+         * When the display name resolves to a repo item, [ItemNameResolver] answers before this
+         * enum is ever reached, so the entry has to use that item's id. An invented id fails
+         * silently instead: every comparison against it never matches.
          */
         @HandleEvent
-        private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
-            val conflicts = entries.filter { it.internalName.getItemStackOrNull() != null }
-            if (conflicts.isEmpty()) return
+        private fun onNeuRepoReload() {
+            // the item name lookup needs NeuItems.allItemsCache, which is filled by another handler of this event
+            DelayedRun.runNextTick {
+                val conflicts = entries.mapNotNull { currency ->
+                    val id = currency.internalName
+                    val resolved = ItemNameResolver.getInternalNameOrNull(currency.displayName)
+                    when {
+                        resolved != null && resolved != id -> "${currency.name} should use ${resolved.asString()}"
+                        resolved == null && id.getItemStackOrNull() != null ->
+                            "${currency.name} uses ${id.asString()}, which is a different repo item"
 
-            ErrorManager.logErrorStateWithData(
-                "A SkyHanni currency id is also a real item, please report this in discord",
-                "SkyblockCurrency internal names collide with NEU repo items",
-                "conflicts" to conflicts.map { it.internalName.asString() },
-            )
+                        else -> null
+                    }
+                }
+                if (conflicts.isEmpty()) return@runNextTick
+
+                ErrorManager.logErrorStateWithData(
+                    "A SkyHanni currency uses a wrong id, please report this in discord",
+                    "SkyblockCurrency entries do not match the repo item behind their name",
+                    "conflicts" to conflicts,
+                )
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -1,0 +1,75 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+
+/**
+ * Currencies that can appear in an item cost lore, but are not real items in the NEU repo.
+ *
+ * [coinValue] is the worth of a single unit in coins, or null when unknown.
+ * [loreNames] are the names as written in the lore, lowercase and without color codes.
+ */
+enum class SkyblockCurrency(
+    val internalName: NeuInternalName,
+    val displayName: String,
+    val coinValue: Double? = null,
+    private val loreNames: Set<String>,
+) {
+    // Universal
+    COINS(
+        NeuInternalName.SKYBLOCK_COIN,
+        "§6Coins",
+        coinValue = 1.0,
+        loreNames = setOf("coin", "coins", "skyblock coin", "skyblock coins", "skyblock_coin", "skyblock_coins"),
+    ),
+
+    // Bits Shop from Elisabeth
+    BITS("BITS".toInternalName(), "§bBits", loreNames = setOf("bit", "bits")),
+
+    // Pesthunter's Wares in Garden
+    PESTS("PESTS".toInternalName(), "§2Pests", loreNames = setOf("pest", "pests")),
+
+    // Chocolate Factory
+    CHOCOLATE("CHOCOLATE".toInternalName(), "§6Chocolate", loreNames = setOf("chocolate")),
+
+    // Anita and SkyMart in Garden
+    COPPER("COPPER".toInternalName(), "§cCopper", loreNames = setOf("copper")),
+    GOLD_MEDAL("GOLD_MEDAL".toInternalName(), "§6Gold medal", loreNames = setOf("gold medal", "gold medals")),
+    SILVER_MEDAL("SILVER_MEDAL".toInternalName(), "§fSilver medal", loreNames = setOf("silver medal", "silver medals")),
+    BRONZE_MEDAL("BRONZE_MEDAL".toInternalName(), "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals")),
+    ;
+
+    @SkyHanniModule
+    companion object {
+
+        private val byInternalName by lazy { entries.associateBy { it.internalName } }
+
+        fun getByInternalNameOrNull(internalName: NeuInternalName): SkyblockCurrency? = byInternalName[internalName]
+
+        fun getByLoreNameOrNull(name: String): SkyblockCurrency? {
+            val clean = name.removeColor().lowercase()
+            return entries.firstOrNull { clean in it.loreNames }
+        }
+
+        /**
+         * A currency id that is also a real repo item would lose its price,
+         * since [ItemPriceUtils.getPriceOrNull] answers from this enum first.
+         */
+        @HandleEvent
+        private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+            val conflicts = entries.filter { it.internalName.getItemStackOrNull() != null }
+            if (conflicts.isEmpty()) return
+
+            ErrorManager.logErrorStateWithData(
+                "A SkyHanni currency id is also a real item, please report this in discord",
+                "SkyblockCurrency internal names collide with NEU repo items",
+                "conflicts" to conflicts.map { it.internalName.asString() },
+            )
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -1,10 +1,14 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.BitsApi
+import at.hannibal2.skyhanni.data.PurseApi
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.ChocolateAmount
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -28,6 +32,8 @@ enum class SkyblockCurrency(
     val displayName: String,
     val coinValue: Double? = null,
     private val loreNames: Set<String>,
+    /** How much of this currency the player owns, or 0 when SkyHanni does not track it. */
+    private val ownedAmount: (() -> Long),
 ) {
     // Universal
     COINS(
@@ -35,30 +41,64 @@ enum class SkyblockCurrency(
         "§6Coins",
         coinValue = 1.0,
         loreNames = setOf("coin", "coins", "skyblock coin", "skyblock coins", "skyblock_coin", "skyblock_coins"),
+        ownedAmount = { PurseApi.currentPurse.toLong() },
     ),
 
-    // Bits Shop from Elizabeth
-    BITS("BITS".toInternalName(), "§bBits", loreNames = setOf("bit", "bits")),
+    // Bits Shop from Elisabeth
+    BITS("BITS".toInternalName(), "§bBits", loreNames = setOf("bit", "bits"), ownedAmount = { BitsApi.bits.toLong() }),
 
     // Pesthunter's Wares in Garden
-    PESTS("PESTS".toInternalName(), "§2Pests", loreNames = setOf("pest", "pests")),
+    PESTS(
+        "PESTS".toInternalName(), "§2Pests", loreNames = setOf("pest", "pests"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
 
     // Chocolate Factory
-    CHOCOLATE("CHOCOLATE".toInternalName(), "§6Chocolate", loreNames = setOf("chocolate")),
+    CHOCOLATE(
+        "CHOCOLATE".toInternalName(),
+        "§6Chocolate",
+        loreNames = setOf("chocolate"),
+        ownedAmount = { ChocolateAmount.CURRENT.chocolate() + ChocolateAmount.chocolateSinceUpdate() },
+    ),
 
     // SkyMart in Garden
-    COPPER(NeuInternalName.SKYBLOCK_COPPER, "§cCopper", loreNames = setOf("copper")),
+    COPPER(
+        NeuInternalName.SKYBLOCK_COPPER, "§cCopper", loreNames = setOf("copper"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
 
     // Anita in Garden
-    GOLD_MEDAL(NeuInternalName.SKYBLOCK_GOLD_MEDAL, "§6Gold medal", loreNames = setOf("gold medal", "gold medals")),
-    SILVER_MEDAL(NeuInternalName.SKYBLOCK_SILVER_MEDAL, "§fSilver medal", loreNames = setOf("silver medal", "silver medals")),
-    BRONZE_MEDAL(NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals")),
+    GOLD_MEDAL(
+        NeuInternalName.SKYBLOCK_GOLD_MEDAL, "§6Gold medal", loreNames = setOf("gold medal", "gold medals"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
+    SILVER_MEDAL(
+        NeuInternalName.SKYBLOCK_SILVER_MEDAL, "§fSilver medal", loreNames = setOf("silver medal", "silver medals"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
+    BRONZE_MEDAL(
+        NeuInternalName.SKYBLOCK_BRONZE_MEDAL, "§cBronze medal", loreNames = setOf("bronze medal", "bronze medals"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
 
     // Tony's Shop in the Farming Islands
-    PELTS("PELTS".toInternalName(), "§5Pelts", loreNames = setOf("pelt", "pelts")),
+    PELTS(
+        "PELTS".toInternalName(), "§5Pelts", loreNames = setOf("pelt", "pelts"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
 
     // Cosmetics in various shops
-    GEMS("GEMS".toInternalName(), "§aGems", loreNames = setOf("gem", "gems")),
+    GEMS(
+        "GEMS".toInternalName(), "§aGems", loreNames = setOf("gem", "gems"),
+        // TODO add
+        ownedAmount = { 0 },
+    ),
     ;
 
     /**
@@ -66,6 +106,11 @@ enum class SkyblockCurrency(
      * Returns null for currencies written the other way around, like "Gold medal §8x2".
      */
     fun readAmountOrNull(text: String): Long? = readCurrencyOrNull(text)?.takeIf { it.first == this }?.second
+
+    fun getOwnedAmount(): Long = ownedAmount.invoke()
+
+    /** Formats an amount the way it appears in a cost lore, for example "§b5,000 Bits". */
+    fun formatAmount(amount: Long): String = displayName.take(2) + amount.addSeparators() + " " + displayName.removeColor()
 
     @SkyHanniModule
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -100,14 +100,6 @@ object UtilsPatterns {
         "(?<name>(?:§.)*(?:[^§] ?)+)(?:§8x(?<amount>[\\d,]+))?",
     )
 
-    /**
-     * REGEX-TEST: §7Cost
-     */
-    val costLinePattern by patternGroup.pattern(
-        "item.cost.line",
-        "(?:§5§o)?§7Cost.*",
-    )
-
     @Suppress("MaxLineLength")
     val timeAmountPattern by patternGroup.pattern(
         "time.amount",


### PR DESCRIPTION
## What
Items are found by their cost lore instead of by inventory name, so the feature also works in
shops we have never seen.

`SkyblockCurrency` covers currencies written as "amount name", which the existing item parsing
cannot read, and is also where the owned amount of a currency is looked up.

The fix below comes out of replacing the old `loreCosts()` helper, which dropped the amounts,
and could not be split into its own PR.

<details>
<summary>Images</summary>

<img width="613" height="508" alt="image" src="https://github.com/user-attachments/assets/3deebddf-ff59-4cff-b5f8-6e2e6814243d" />

<img width="606" height="627" alt="image" src="https://github.com/user-attachments/assets/80bc345c-63bb-42a7-881a-51381969c6ee" />

</details>

## Changelog New Features
+ Added NPC Trade Helper.  - hannibal2
    * Highlights items in NPC trade menus that you can buy right now.
    * Also shows the price, the number you own and the total cost in the item lore.

## Changelog Fixes
+ Fixed additional cost in the Chocolate Shop and SkyMart overlays ignoring the number of items. - hannibal2

## Changelog Technical Details
+ Merged the duplicated cost lore parsers of six features into LoreCostUtils. - hannibal2
+ Added SkyblockCurrency for currencies that appear in cost lores. - hannibal2