### PR TITLE
Backend: Replace deprecated IslandChangeEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.mob.Mob
-import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.SkyHanniWarpEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
@@ -56,9 +56,9 @@ object EntityMovementData {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    private fun onIslandJoin(event: IslandJoinEvent) {
         val nextData = nextTeleport ?: return
-        if (nextData.island != event.newIsland) return
+        if (nextData.island != event.island) return
         val passedSince = nextData.startTime.passedSince()
         if (passedSince > 5.seconds) {
             nextTeleport = null
@@ -72,7 +72,7 @@ object EntityMovementData {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
+    private fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
         val nextData = nextTeleport ?: return
 
         val passedSince = nextData.startTime.passedSince()
@@ -88,7 +88,7 @@ object EntityMovementData {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick() {
+    private fun onTick() {
         addToTrack(MinecraftCompat.localPlayerOrThrow)
 
         for (entity in entityLocation.keys) {
@@ -105,7 +105,7 @@ object EntityMovementData {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!warpingPattern.matches(event.message)) return
         DelayedRun.runNextTick {
             SkyHanniWarpEvent.post()
@@ -113,7 +113,7 @@ object EntityMovementData {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         entityLocation.clear()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CommunityFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CommunityFix.kt
@@ -36,7 +36,7 @@ object CommunityFix {
     /**
      * REGEX-TEST: §2§l§m       §f§l§m             §r §e676,985§6/§e2M
      */
-    private val amountPattern by RepoPattern.pattern(
+    private val progressPattern by RepoPattern.pattern(
         "data.garden.milestonefix.amount",
         ".*§e(?<having>.*)§6/§e(?<max>.*)",
     )
@@ -45,7 +45,7 @@ object CommunityFix {
     private var showWhenAllCorrect = false
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<GardenJson>("Garden")
         val map = data.cropMilestoneCommunityHelp
         for ((key, value) in map) {
@@ -97,7 +97,7 @@ object CommunityFix {
         val next = lore.nextAfter({ totalPattern.matches(it) }, 3) ?: return
 
         val guessNextMax = nextMax(realTier, crop)
-        val nextMax = amountPattern.matchMatcher(next) {
+        val nextMax = progressPattern.matchMatcher(next) {
             group("max").formatLong()
         } ?: return
 
@@ -126,7 +126,6 @@ object CommunityFix {
     private var totalFixedValues = 0
 
     private fun handleInput(input: String) {
-        println(" ")
         var fixed = 0
         var alreadyCorrect = 0
         for (line in input.lines()) {
@@ -167,7 +166,7 @@ object CommunityFix {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shreadcropmilestonefromclipboard") {
             description = "Read crop milestone from clipboard. This helps fixing wrong crop milestone data"
             category = CommandCategory.DEVELOPER_TEST

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -7,11 +7,8 @@ import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.graph.Graph
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SkyHanniWarpEvent
@@ -171,7 +168,7 @@ object TunnelsMaps {
     private var display: List<Renderable> = listOf()
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
         clickTranslate = mapOf()
         if (!commissionInvPattern.matches(event.inventoryName)) return
@@ -211,12 +208,12 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         clickTranslate = mapOf()
     }
 
     @HandleEvent
-    fun onTooltip(event: ToolTipTextEvent) {
+    private fun onTooltip(event: ToolTipTextEvent) {
         if (!isEnabled()) return
         event.slot ?: return
         clickTranslate[event.slot.containerSlot]?.let {
@@ -225,7 +222,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
         if (event.clickedButton != 1) return
         clickTranslate[event.slotId]?.let {
@@ -235,7 +232,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         graph = event.getConstant<Graph>("island_graphs/GLACITE_TUNNELS")
         possibleLocations = graph.groupBy { it.name }.filterNotNullKeys().mapValues { (_, value) ->
             value
@@ -269,7 +266,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    private fun onConfigLoad() {
         onToggle(
             config.compactGemstone,
             config.excludeFairy,
@@ -280,7 +277,7 @@ object TunnelsMaps {
 
     @HandleEvent
     @Suppress("AvoidBritishSpelling")
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(84, "mining.tunnelMaps.pathColour", "mining.tunnelMaps.pathColor")
         event.move(84, "mining.tunnelMaps.dynamicPathColour", "mining.tunnelMaps.dynamicPathColor")
     }
@@ -396,7 +393,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         if (!isEnabled()) return
         if (checkGoalReached()) return
         val prevClosest = closestNode
@@ -453,7 +450,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
         val path = path?.takeIf { it.first.isNotEmpty() } ?: return
         event.draw3DPathWithWaypoint(
@@ -484,37 +481,38 @@ object TunnelsMaps {
     } ?: config.pathColor.toColor()
 
     @HandleEvent
-    fun onKeyPress(event: KeyPressEvent) {
+    private fun onKeyPress(event: KeyPressEvent) {
         if (!isEnabled()) return
         if (MinecraftCompat.screen != null) return
-        campfireKey(event)
-        nextSpotKey(event)
+        val keyCode = event.keyCode
+        campfireKey(keyCode)
+        nextSpotKey(keyCode)
     }
 
     @HandleEvent
-    fun onItemClick(event: ItemClickEvent) {
+    private fun onItemClick(event: ItemClickEvent) {
         if (!isEnabled() || !config.leftClickPigeon) return
         if (event.clickType != InteractClickType.LEFT_CLICK) return
         if (event.itemInHand?.getInternalNameOrNull() != ROYAL_PIGEON) return
         nextSpot()
     }
 
-    private fun campfireKey(event: KeyPressEvent) {
-        if (event.keyCode != config.campfireKey) return
+    private fun campfireKey(keyCode: Int) {
+        if (keyCode != config.campfireKey) return
         if (lastBaseCampWarp.passedSince() < 2.seconds) return
         lastBaseCampWarp = SimpleTimeMark.now()
         if (config.travelScroll) HypixelCommands.warp("basecamp") else campfireOverride()
     }
 
     @HandleEvent
-    fun onWarp(event: SkyHanniWarpEvent) {
+    private fun onWarp(event: SkyHanniWarpEvent) {
         if (!isEnabled() || goal == null) return
         DelayedRun.runNextTick { setNextGoal() }
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        if (closestNode == null) return // Value that must be none null if it was active
+    private fun onIslandLeave() {
+        if (closestNode == null) return // value that must be non null if it was active
         closestNode = null
         clearPath()
         cooldowns.clear()
@@ -523,9 +521,10 @@ object TunnelsMaps {
 
     private var nextSpotDelay = SimpleTimeMark.farPast()
 
-    private fun nextSpotKey(event: KeyPressEvent) {
-        if (event.keyCode != config.nextSpotHotkey) return
-        nextSpot()
+    private fun nextSpotKey(keyCode: Int) {
+        if (keyCode == config.nextSpotHotkey) {
+            nextSpot()
+        }
     }
 
     private fun nextSpot() {


### PR DESCRIPTION
## What

`EntityMovementData` only ever reacted to entering an island, so it maps onto `IslandJoinEvent`. `TunnelsMaps` never read the event and only resets state, so `IslandLeaveEvent` fits. Behavior is unchanged in both.

Drive-by in the same files: event handlers are private now, `TunnelsMaps` drops three unused event parameters, `amountPattern` became `progressPattern`, and a leftover debug `println` is gone.

## Changelog Technical Details
+ Replaced the deprecated IslandChangeEvent with IslandJoinEvent and IslandLeaveEvent in EntityMovementData and TunnelsMaps. - hannibal2